### PR TITLE
Added @Session decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ To inject a whole session object, use `@Session` decorator:
 
 ```typescript
 @Post("/login/")
-loginUser(@Session() session: express.Session, @Body() user: User) {
+loginUser(@Session() session: Express.Session, @Body() user: User) {
 }
 ```
 
@@ -361,6 +361,9 @@ To inject a single object from session, use `@Session` decorator with parameter:
 savePost(@Session("user") user: User, @Body() post: Post) {
 }
 ```
+
+Routing-controllers uses [express-session][5] to handle session, so firstly you have to install it manually to use `@Session` decorator.
+This feature is not supported by koa driver yet.
 
 #### Inject uploaded file
 
@@ -1035,3 +1038,4 @@ See information about breaking changes and release notes [here](https://github.c
 [2]: http://koajs.com/
 [3]: https://github.com/expressjs/multer
 [4]: https://github.com/pleerock/class-transformer
+[5]: https://www.npmjs.com/package/express-session

--- a/README.md
+++ b/README.md
@@ -344,6 +344,24 @@ saveUser(@HeaderParam("authorization") token: string) {
 }
 ```
 
+#### Inject session object
+
+To inject a whole session object, use `@Session` decorator:
+
+```typescript
+@Post("/login/")
+loginUser(@Session() session: express.Session, @Body() user: User) {
+}
+```
+
+To inject a single object from session, use `@Session` decorator with parameter:
+
+```typescript
+@Get("/login/")
+savePost(@Session("user") user: User, @Body() post: Post) {
+}
+```
+
 #### Inject uploaded file
 
 To inject uploaded file, use `@UploadedFile` decorator:
@@ -960,6 +978,8 @@ export class UsersController {
 | `@Res()`                                                           | `getAll(@Res() response: Response)`              | Injects a Reponse object to a controller action parameter value                                                                                                                                                                                                              | `function (request, response)`            |
 | `@Body(options?: ParamOptions)`                                    | `post(@Body() body: any)`                        | Injects a body to a controller action parameter value. In options you can specify if body should be parsed into a json object or not. Also you can specify there if body is required and action cannot work without body being specified.                                    | `request.body`                            |
 | `@Param(name: string, options?: ParamOptions)`                     | `get(@Param("id") id: number)`                   | Injects a parameter to a controller action parameter value. In options you can specify if parameter should be parsed into a json object or not. Also you can specify there if parameter is required and action cannot work with empty parameter.                             | `request.params.id`                       |
+| `@Session(objectName: string, options?: ParamOptions)`             | `get(@Session("user") user: User)`               | Injects an object from session to a controller action parameter value. In options you can specify there if parameter is not required and action can work with empty parameter.                             | `request.session.user`                       |
+| `@Session()`                                                       | `get(@Session() session: express.Session)`       | Injects a whole session object to a controller action parameter value. A session object is required and action cannot work with empty parameter.                             | `request.session`                       |
 | `@QueryParam(name: string, options?: ParamOptions)`                | `get(@QueryParam("id") id: number)`              | Injects a query string parameter to a controller action parameter value. In options you can specify if parameter should be parsed into a json object or not. Also you can specify there if query parameter is required and action cannot work with empty parameter.          | `request.query.id`                        |
 | `@HeaderParam(name: string, options?: ParamOptions)`               | `get(@HeaderParam("token") token: string)`       | Injects a parameter from response headers to a controller action parameter value. In options you can specify if parameter should be parsed into a json object or not. Also you can specify there if query parameter is required and action cannot work with empty parameter. | `request.headers.token`                   |
 | `@UploadedFile(name: string, options?: { required?: boolean })`    | `post(@UploadedFile("files") file: any)`         | Injects a "file" from the response to a controller action parameter value. In parameter options you can specify if this is required parameter or not. parseJson option is ignored                                                                                            | `request.file.file` (when using multer)   |

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "del": "^2.2.1",
     "es6-shim": "^0.35.1",
     "express": "^4.14.0",
+    "express-session": "^1.14.1",
     "gulp": "^3.9.1",
     "gulp-istanbul": "^1.0.0",
     "gulp-mocha": "^2.2.0",

--- a/sample/sample12-session-support/UserController.ts
+++ b/sample/sample12-session-support/UserController.ts
@@ -1,0 +1,48 @@
+import "reflect-metadata";
+import {Request} from "express";
+import {Controller} from "../../src/decorator/controllers";
+import {Get, Post, Put, Patch, Delete} from "../../src/decorator/methods";
+import {Session, Req, Param} from "../../src/decorator/params";
+import {JsonResponse} from "../../src/decorator/decorators";
+
+@Controller()
+export class UserController {
+
+    @Get("/users")
+    @JsonResponse()
+    getAll() {
+        return [
+            { id: 1, name: "First user!" },
+            { id: 2, name: "Second user!" }
+        ];
+    }
+
+    @Get("/users/:id")
+    @JsonResponse()
+    getOne(@Session("user") user: any) {
+        return user;
+    }
+
+    @Post("/users")
+    post(@Req() request: Request) {
+        let user = JSON.stringify(request.body); // probably you want to install body-parser for express
+        return "User " + user + " !saved!";
+    }
+
+    @Put("/users/:id")
+    put(@Param("id") id: number, @Session() session: Express.Session) {
+        (session as any).user = { name: "test", number: id };
+        return "User has been putted!";
+    }
+
+    @Patch("/users/:id")
+    patch(@Req() request: Request) {
+        return "User #" + request.params.id + " has been patched!";
+    }
+
+    @Delete("/users/:id")
+    remove(@Req() request: Request) {
+        return "User #" + request.params.id + " has been removed!";
+    }
+
+}

--- a/sample/sample12-session-support/app.ts
+++ b/sample/sample12-session-support/app.ts
@@ -1,0 +1,14 @@
+import "reflect-metadata";
+import {useExpressServer} from "../../src/index";
+import * as express from "express";
+import * as session from "express-session";
+
+require("./UserController");
+
+const app = express();
+app.use(session()); // use session middleware
+
+useExpressServer(app); // register controllers routes in our express application
+app.listen(3001); // run express app
+
+console.log("Express server is running on port 3001. Open http://localhost:3001/users/");

--- a/src/decorator/params.ts
+++ b/src/decorator/params.ts
@@ -69,6 +69,31 @@ export function Param(name: string) {
 }
 
 /**
+ * This decorator allows to inject a session object to the controller action parameter.
+ * Applied to class method parameters.
+ *
+ * @param objectName The name of object stored in session
+ */
+export function Session(objectName?: string) {
+    return function (object: Object, methodName: string, index: number) {
+        let format = (Reflect as any).getMetadata("design:paramtypes", object, methodName)[index];
+        const metadata: ParamMetadataArgs = {
+            target: object.constructor,
+            method: methodName,
+            index: index,
+            type: ParamTypes.SESSION,
+            reflectedType: format,
+            name: objectName,
+            format: format,
+            parseJson: false, // it does not make sense for Session to be parsed
+            isRequired: true, // when we demand session object, it must exist (working session middleware)
+            classTransformOptions: undefined
+        };
+        defaultMetadataArgsStorage().params.push(metadata);
+    };
+}
+
+/**
  * This decorator allows to inject a query parameter value to the controller action parameter.
  * Applied to class method parameters.
  *

--- a/src/driver/ExpressDriver.ts
+++ b/src/driver/ExpressDriver.ts
@@ -149,6 +149,12 @@ export class ExpressDriver extends BaseDriver implements Driver {
                 return request.body;
             case ParamTypes.PARAM:
                 return request.params[param.name];
+            case ParamTypes.SESSION:
+                if (param.name) {
+                    return request.session[param.name]; 
+                } else {
+                    return request.session;
+                }
             case ParamTypes.QUERY:
                 return request.query[param.name];
             case ParamTypes.HEADER:

--- a/src/driver/KoaDriver.ts
+++ b/src/driver/KoaDriver.ts
@@ -160,6 +160,9 @@ export class KoaDriver extends BaseDriver implements Driver {
                 return request.body;
             case ParamTypes.PARAM:
                 return context.params[param.name];
+            case ParamTypes.SESSION:
+                throw new Error("@Session decorator is not supported by KoaDriver yet.");
+                // TODO return session
             case ParamTypes.QUERY:
                 return context.query[param.name];
             case ParamTypes.UPLOADED_FILE:

--- a/src/metadata/types/ParamTypes.ts
+++ b/src/metadata/types/ParamTypes.ts
@@ -1,7 +1,7 @@
 /**
  * Controller action's parameter type.
  */
-export type ParamType = "body"|"query"|"header"|"file"|"files"|"body_param"|"param"|"cookie"|"request"|"response"|"custom_converter";
+export type ParamType = "body"|"query"|"header"|"file"|"files"|"body_param"|"param"|"session"|"cookie"|"request"|"response"|"custom_converter";
 
 /**
  * Controller action's parameter type.
@@ -14,6 +14,7 @@ export class ParamTypes {
     static UPLOADED_FILES: ParamType = "files";
     static BODY_PARAM: ParamType = "body_param";
     static PARAM: ParamType = "param";
+    static SESSION: ParamType = "session";
     static COOKIE: ParamType = "cookie";
     static REQUEST: ParamType = "request";
     static RESPONSE: ParamType = "response";

--- a/test/functional/action-params.spec.ts
+++ b/test/functional/action-params.spec.ts
@@ -102,6 +102,11 @@ describe("action parameters", () => {
             }))
             addToSession(@Session() session: Express.Session) {
                 (session as any).testElement = "@Session test";
+                (session as any).fakeObject = {
+                    name: "fake",
+                    fake: true,
+                    value: 666
+                };
                 return `<html><body>@Session</body></html>`;
             }
 
@@ -307,7 +312,6 @@ describe("action parameters", () => {
             expect(response).to.have.header("content-type", "text/html; charset=utf-8");
             expect(response.body).to.be.equal("<html><body>@Session</body></html>");
             assertRequest([3001], "get", "session", response => {
-                paramUserId.should.be.equal(1);
                 expect(response).to.be.status(200);
                 expect(response).to.have.header("content-type", "text/html; charset=utf-8");
                 expect(response.body).to.be.equal("<html><body>@Session test</body></html>");

--- a/test/functional/action-params.spec.ts
+++ b/test/functional/action-params.spec.ts
@@ -1,8 +1,11 @@
 import "reflect-metadata";
+import * as session from "express-session";
 import {Controller} from "../../src/decorator/controllers";
 import {Get, Post} from "../../src/decorator/methods";
+import {UseBefore} from "../../src/decorator/decorators";
 import {createExpressServer, defaultMetadataArgsStorage, createKoaServer} from "../../src/index";
 import {
+    Session,
     Param,
     QueryParam,
     HeaderParam,
@@ -22,6 +25,7 @@ const expect = chakram.expect;
 describe("action parameters", () => {
 
     let paramUserId: number, paramFirstId: number, paramSecondId: number;
+    let sessionTestElement: string;
     let queryParamSortBy: string, queryParamCount: string, queryParamLimit: number, queryParamShowAll: boolean, queryParamFilter: any;
     let headerParamToken: string, headerParamCount: number, headerParamLimit: number, headerParamShowAll: boolean, headerParamFilter: any;
     let cookieParamToken: string, cookieParamCount: number, cookieParamLimit: number, cookieParamShowAll: boolean, cookieParamFilter: any;
@@ -36,6 +40,7 @@ describe("action parameters", () => {
         paramUserId = undefined;
         paramFirstId = undefined;
         paramSecondId = undefined;
+        sessionTestElement = undefined;
         queryParamSortBy = undefined;
         queryParamCount = undefined;
         queryParamLimit = undefined;
@@ -89,6 +94,24 @@ describe("action parameters", () => {
                 paramFirstId = firstId;
                 paramSecondId = secondId;
                 return `<html><body>${firstId},${secondId}</body></html>`;
+            }
+
+            @Post("/session/")
+            @UseBefore(session({
+                secret: "19majkel94_helps_pleerock",
+            }))
+            addToSession(@Session() session: Express.Session) {
+                (session as any).testElement = "@Session test";
+                return `<html><body>@Session</body></html>`;
+            }
+
+            @Get("/session/")
+            @UseBefore(session({
+                secret: "19majkel94_helps_pleerock",
+            }))
+            loadFromSession(@Session("testElement") testElement: string) {
+                sessionTestElement = testElement;
+                return `<html><body>${testElement}</body></html>`;
             }
 
             @Get("/photos")
@@ -275,6 +298,21 @@ describe("action parameters", () => {
             expect(response).to.be.status(200);
             expect(response).to.have.header("content-type", "text/html; charset=utf-8");
             expect(response.body).to.be.equal("<html><body>23,32</body></html>");
+        });
+    });
+
+    describe("@Session should return a value from session", () => {
+        assertRequest([3001], "post", "session", response => {
+            expect(response).to.be.status(200);
+            expect(response).to.have.header("content-type", "text/html; charset=utf-8");
+            expect(response.body).to.be.equal("<html><body>@Session</body></html>");
+            assertRequest([3001], "get", "session", response => {
+                paramUserId.should.be.equal(1);
+                expect(response).to.be.status(200);
+                expect(response).to.have.header("content-type", "text/html; charset=utf-8");
+                expect(response.body).to.be.equal("<html><body>@Session test</body></html>");
+                expect(sessionTestElement).to.be.equal("@Session test");
+            });
         });
     });
 

--- a/typings.json
+++ b/typings.json
@@ -1,8 +1,9 @@
 {
   "globalDevDependencies": {
-    "koa": "registry:dt/koa#2.0.0+20160619030120",
     "assertion-error": "registry:dt/assertion-error#1.0.0+20141105053942",
     "chai": "registry:dt/chai#3.4.0+20160216071402",
+    "express-session": "registry:dt/express-session#0.0.0+20160819134112",
+    "koa": "registry:dt/koa#2.0.0+20160619030120",
     "mocha": "registry:dt/mocha#2.2.5+20151023103246",
     "sinon": "registry:dt/sinon#1.16.0+20151027143416"
   },


### PR DESCRIPTION
Implemented issue #30.
Works for injecting whole session object - `@Session() session: Express.Session` or with single object from session - `@Session("objectName") object: ObjectType`.