### PR TITLE
Define with exactly type for express

### DIFF
--- a/src/driver/ExpressDriver.ts
+++ b/src/driver/ExpressDriver.ts
@@ -1,3 +1,4 @@
+import * as express from "express";
 import {HttpError} from "../error/http/HttpError";
 import {UseMetadata} from "../metadata/UseMetadata";
 import {MiddlewareMetadata} from "../metadata/MiddlewareMetadata";
@@ -23,11 +24,11 @@ export class ExpressDriver extends BaseDriver implements Driver {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(public express?: any) {
+    constructor(public express?: express.Express) {
         super();
         if (require) {
             if (!express) {
-                try {
+                try {                  
                     this.express = require("express")();
                 } catch (e) {
                     throw new Error("express package was not found installed. Try to install it: npm install express --save");
@@ -77,7 +78,7 @@ export class ExpressDriver extends BaseDriver implements Driver {
                    interceptors: InterceptorMetadata[],
                    executeCallback: (options: ActionCallbackOptions) => any): void {
         const expressAction = action.type.toLowerCase();
-        if (!this.express[expressAction])
+        if (!(this.express as any)[expressAction])
             throw new BadHttpActionError(action.type);
 
         const useInterceptors = action.controllerMetadata.useInterceptors.concat(action.useInterceptors);
@@ -133,7 +134,7 @@ export class ExpressDriver extends BaseDriver implements Driver {
         const expressParams: any[] = [fullRoute, ...preMiddlewareFunctions, ...defaultMiddlewares, routeHandler, ...postMiddlewareFunctions];
 
         // finally register action
-        this.express[expressAction](...expressParams);
+        (this.express as any)[expressAction](...expressParams);
     }
 
     registerRoutes() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as express from "express";
 import {MetadataArgsStorage} from "./metadata-builder/MetadataArgsStorage";
 import {importClassesFromDirectories} from "./util/DirectoryExportedClassesLoader";
 import {RoutingControllerExecutor} from "./RoutingControllerExecutor";
@@ -14,7 +15,7 @@ import {RoutingControllersOptions} from "./RoutingControllersOptions";
 /**
  * Registers all loaded actions in your express application.
  */
-export function useExpressServer<T>(expressApp: T, options?: RoutingControllersOptions): T {
+export function useExpressServer(expressApp: express.Express, options?: RoutingControllersOptions): express.Express {
     createExecutor(new ExpressDriver(expressApp), options || {});
     return expressApp;
 }
@@ -22,7 +23,7 @@ export function useExpressServer<T>(expressApp: T, options?: RoutingControllersO
 /**
  * Registers all loaded actions in your express application.
  */
-export function createExpressServer(options?: RoutingControllersOptions): any {
+export function createExpressServer(options?: RoutingControllersOptions): express.Express {
     const driver = new ExpressDriver();
     createExecutor(driver, options || {});
     return driver.express;


### PR DESCRIPTION
Hi @pleerock 

I suggest createExpressServer should return `express.Express` type and ExpressDriver.express sets  `express.Express` type.
I don't want when I call the **createExpressServer** function, it will return an `any` value. In TypeScript,  It's not convenience to me if I need the value show its properties.

So, I improve the type definition accuracy and avoid to use `any` type on argument and return value.