### PR TITLE
missing "typings" in package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,6 @@
   },
   "scripts": {
     "test": "gulp tests"
-  }
+  },
+  "typings": "index.d.ts"
 }


### PR DESCRIPTION
this is required for typescript to find and resolve the module and its typings :)

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html