### PR TITLE
Koa Render Closes #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,9 @@ getOne() {
 To use rendering ability make sure to configure express properly.
 [Here](https://github.com/pleerock/routing-controllers/blob/0.6.0-release/test/functional/render-decorator.spec.ts)
 is a test where you can take a look how to do it.
-This feature is not supported by koa driver yet.
+
+To use rendering ability with Koa you will need to use a rendering 3rd party such as [koa-views](https://github.com/queckezz/koa-views/), 
+koa-views is the only render middleware that has been tested.
 
 ## Using middlewares
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "koa": "^2.0.0",
     "koa-bodyparser": "^3.1.0",
     "koa-router": "^7.0.1",
+    "koa-views": "^5.2.0",
     "mocha": "^3.0.0",
     "multer": "^1.1.0",
     "mustache-express": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-tslint": "^6.0.1",
     "gulp-typescript": "^2.13.6",
     "gulpclass": "^0.1.1",
+    "handlebars": "^4.0.6",
     "koa": "^2.0.0",
     "koa-bodyparser": "^3.1.0",
     "koa-router": "^7.0.1",

--- a/sample/sample13-koa-views-render/BlogController.ts
+++ b/sample/sample13-koa-views-render/BlogController.ts
@@ -1,0 +1,26 @@
+import "reflect-metadata";
+import {Controller} from "../../src/decorator/controllers";
+import {Get, Post, Put, Patch, Delete} from "../../src/decorator/methods";
+import {Render} from "../../src/decorator/decorators";
+
+@Controller()
+export class UserController {
+
+    @Get("/")
+    @Render("blog.html")
+    blog() {
+        return {
+            title: "My Blog",
+            posts: [
+                {
+                    title: "Welcome to my blow",
+                    content: "This is my new blog built with Koa, routing-controllers and koa-views"
+                },
+                {
+                    title: "Hello World",
+                    content: "Hello world from Koa and routing-controllers"
+                }
+            ]
+        };
+    }
+}

--- a/sample/sample13-koa-views-render/BlogController.ts
+++ b/sample/sample13-koa-views-render/BlogController.ts
@@ -13,7 +13,7 @@ export class UserController {
             title: "My Blog",
             posts: [
                 {
-                    title: "Welcome to my blow",
+                    title: "Welcome to my blog",
                     content: "This is my new blog built with Koa, routing-controllers and koa-views"
                 },
                 {

--- a/sample/sample13-koa-views-render/app.ts
+++ b/sample/sample13-koa-views-render/app.ts
@@ -1,0 +1,17 @@
+import "reflect-metadata";
+import * as Koa from "koa";
+
+import {useKoaServer} from "../../src/index";
+
+require("./BlogController");
+
+const koa = new Koa();
+const app = useKoaServer(koa);
+const path = __dirname + "/../../../../sample/sample13-koa-views-render";
+
+let koaViews = require("koa-views");
+app.use(koaViews(path, { map: { html: "handlebars" } } ));
+
+app.listen(3001); // run koa app
+
+console.log("Koa server is running on port 3001. Open http://localhost:3001/");

--- a/sample/sample13-koa-views-render/blog.html
+++ b/sample/sample13-koa-views-render/blog.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>{{title}}</title>
+    </head>
+    <body>
+        <h1>{{title}}</h1>
+        {{#each posts}}
+            <h2>{{this.title}}</h2>
+            <p>{{this.content}}
+        {{/each}}
+    </body>
+</html>

--- a/src/driver/KoaDriver.ts
+++ b/src/driver/KoaDriver.ts
@@ -220,11 +220,8 @@ export class KoaDriver extends BaseDriver implements Driver {
 
         } else if (action.renderedTemplate) { // if template is set then render it // todo: not working in koa
             const renderOptions = result && result instanceof Object ? result : {};
-            // console.log(options.context.render);
-            // options.context.render(action.renderedTemplate, renderOptions);
 
             this.koa.use(async function (ctx: any, next: any) {
-                console.log(renderOptions);
                 await ctx.render(action.renderedTemplate, renderOptions);
             })
 

--- a/src/driver/KoaDriver.ts
+++ b/src/driver/KoaDriver.ts
@@ -220,23 +220,15 @@ export class KoaDriver extends BaseDriver implements Driver {
 
         } else if (action.renderedTemplate) { // if template is set then render it // todo: not working in koa
             const renderOptions = result && result instanceof Object ? result : {};
+            // console.log(options.context.render);
+            // options.context.render(action.renderedTemplate, renderOptions);
 
-            this.koa.render(action.renderedTemplate, renderOptions, (err: any, html: string) => {
-                if (err && action.isJsonTyped) {
-                    options.next(err);
-                    // options.rejecter(err);
+            this.koa.use(async function (ctx: any, next: any) {
+                console.log(renderOptions);
+                await ctx.render(action.renderedTemplate, renderOptions);
+            })
 
-                } else if (err && !action.isJsonTyped) {
-                    options.next(err);
-                    // options.rejecter(err);
-
-                } else if (html) {
-                    response.body = html;
-                }
-                options.next();
-                // options.resolver();
-            });
-
+            options.next();
         } else if (result !== undefined || action.undefinedResultCode) { // send regular result
             if (result === null || (result === undefined && action.undefinedResultCode)) {
 

--- a/src/driver/KoaDriver.ts
+++ b/src/driver/KoaDriver.ts
@@ -223,7 +223,7 @@ export class KoaDriver extends BaseDriver implements Driver {
 
             this.koa.use(async function (ctx: any, next: any) {
                 await ctx.render(action.renderedTemplate, renderOptions);
-            })
+            });
 
             options.next();
         } else if (result !== undefined || action.undefinedResultCode) { // send regular result

--- a/test/functional/render-decorator.spec.ts
+++ b/test/functional/render-decorator.spec.ts
@@ -43,12 +43,16 @@ describe("template rendering", () => {
 
     let koaApp: any;
     before(done => {
-        koaApp = createKoaServer().listen(3002, done);
+        const path = __dirname + "/../../../../test/resources";
+        const server = createKoaServer();
+        var koaViews = require('koa-views');
+        server.use(koaViews(path, { map:{html: 'handlebars'} }));
+        koaApp = server.listen(3002, done);
     });
     after(done => koaApp.close(done));
 
     describe("should render a template and use given variables", () => {
-        assertRequest([3001/*, 3002*/], "get", "index", response => {
+        assertRequest([3001, 3002], "get", "index", response => {
             expect(response).to.have.status(200);
             expect(response.body).to.contain("<html>");
             expect(response.body).to.contain("<body>");

--- a/test/functional/render-decorator.spec.ts
+++ b/test/functional/render-decorator.spec.ts
@@ -45,8 +45,8 @@ describe("template rendering", () => {
     before(done => {
         const path = __dirname + "/../../../../test/resources";
         const server = createKoaServer();
-        var koaViews = require('koa-views');
-        server.use(koaViews(path, { map:{html: 'handlebars'} }));
+        let koaViews = require("koa-views");
+        server.use(koaViews(path, { map: { html: "handlebars" } } ));
         koaApp = server.listen(3002, done);
     });
     after(done => koaApp.close(done));


### PR DESCRIPTION
# Koa Render

Closes #59

## Reason

The KoaDriver render was not completed, it was using the Express way of rendering html templates using Template engines that were loaded into express.

I have decided that I prefer Koa over express so have played around with the KoaDriver to try get the render to work for Koa.

## Dependencies

I have decided to use [Koa-views](https://github.com/queckezz/koa-views) as the rendering middleware, as it allows for loading of different rendering engines easily. In the tests I have edited the Koa before section to load up the rendering middleware and load the handlebars engine by default.

## Fix

The fix I have applied is not very neat but works for now, it creates a middleware in the handleSuccess method of the KoaDriver as I needed access to Koa's context which Koa-views extends and adds the render method to. 

I tried to access the Koa context via options.context but it seem this was using routing-controllers own implementation of the context and was missing the render method. I would love suggestions to remove the middleware within the handleSuccess method and a suggestion on how I could access the Koa context correctly within the KoaDriver.

Would love your feedback @pleerock 

I hope this helps in any way!