### PR TITLE
Exception throwing error fixed

### DIFF
--- a/src/ActionCallbackOptions.ts
+++ b/src/ActionCallbackOptions.ts
@@ -8,6 +8,6 @@ export interface ActionCallbackOptions {
     /**
      * Interceptor functions to be applied for response result.
      */
-    useInterceptorFunctions: Function[];
-    
+    useInterceptorFunctions?: Function[];
+
 }

--- a/src/driver/ExpressDriver.ts
+++ b/src/driver/ExpressDriver.ts
@@ -64,7 +64,7 @@ export class ExpressDriver extends BaseDriver implements Driver {
         if (!middleware.instance.use)
             return;
 
-        this.express.use(function (request: any, response: any, next: (err: any) => any) {
+        this.express.use((request: any, response: any, next: (err: any) => any) => {
 
             try {
                 const useResult = middleware.instance.use(request, response, next);

--- a/test/functional/express-global-before-error-handling.spec.ts
+++ b/test/functional/express-global-before-error-handling.spec.ts
@@ -1,0 +1,75 @@
+import "reflect-metadata";
+import {JsonController} from "../../src/decorator/controllers";
+import {Get} from "../../src/decorator/methods";
+import {createExpressServer} from "../../src/index";
+import {MiddlewareGlobalBefore, MiddlewareGlobalAfter} from "../../src/decorator/decorators";
+import {ErrorMiddlewareInterface} from "../../src/middleware/ErrorMiddlewareInterface";
+import {MiddlewareInterface} from "../../src/middleware/MiddlewareInterface";
+
+
+const chakram = require("chakram");
+const expect = chakram.expect;
+
+describe("custom express global before middleware error handling", () => {
+
+    class CustomError extends Error {
+      name = "CustomError";
+      message = "custom error message!";
+    }
+
+    let errorHandlerCalled: boolean;
+    let errorHandlerName: string;
+
+    beforeEach(() => {
+        errorHandlerCalled = undefined;
+        errorHandlerName = undefined;
+    });
+
+    before(() => {
+
+
+        @MiddlewareGlobalBefore()
+        class GlobalBeforeMiddleware implements MiddlewareInterface {
+            use(request: any, response: any, next?: Function): any {
+              console.log("GLOBAL BEFORE MIDDLEWARE CALLED");
+              throw new CustomError();
+            }
+        }
+
+        @MiddlewareGlobalAfter()
+        class CustomErrorHandler implements ErrorMiddlewareInterface {
+            error(error: any, req: any, res: any, next: any) {
+                errorHandlerCalled = true;
+                errorHandlerName = error.name;
+                res.status(error.httpCode).send(error.message);
+            }
+        }
+
+        @JsonController()
+        class ExpressErrorHandlerController {
+
+          @Get("/answers")
+          answers() {
+            return {
+                id: 1,
+                title: "My answer"
+            };
+          }
+        }
+    });
+
+    let app: any;
+    before(done => app = createExpressServer({defaultErrorHandler: false}).listen(3001, done));
+    after(done => app.close(done));
+
+    it("should call global error handler middleware with CustomError", () => {
+        return chakram
+          .get("http://127.0.0.1:3001/answers")
+          .then((response: any) => {
+              expect(errorHandlerCalled).to.be.true;
+              expect(errorHandlerName).to.equals("CustomError");
+              expect(response).to.have.status(500);
+          });
+    });
+
+});


### PR DESCRIPTION
When throwing an Exception from lower layers of the app, the correct exception wouldn't pop in the global `ErrorMiddleware`. 
Instead, the error`TypeError: Cannot read property 'handle' of undefined` would raise. This was caused by `ExpressDriver` when trying to handle the error. `this` reference was not defined properly in `ExpressDriver.registerMiddleware`. 

Using an anonymous function for the inner middleware, so that `this` is a reference to `ExpressDriver` and not a reference to the inner middleware function.
