### PR TITLE
Fix required error handling

### DIFF
--- a/src/ParamHandler.ts
+++ b/src/ParamHandler.ts
@@ -1,4 +1,6 @@
 import {ParameterParseJsonError} from "./error/ParameterParseJsonError";
+import {ParameterRequiredError} from "./error/ParameterRequiredError";
+import {BodyRequiredError} from "./error/BodyRequiredError";
 import {plainToClass} from "class-transformer";
 import {ParamTypes} from "./metadata/types/ParamTypes";
 import {ParamMetadata} from "./metadata/ParamMetadata";
@@ -45,10 +47,10 @@ export class ParamHandler {
         if (param.isRequired) {
             // todo: make better error messages here
             if (param.name && isValueEmpty) {
-                return Promise.reject("Parameter " + param.name + " is required for request on " + request.method + " " + request.url);
+                return Promise.reject(new ParameterRequiredError(request.url, request.method, param.name));
 
             } else if (!param.name && (isValueEmpty || isValueEmptyObject)) {
-                return Promise.reject("Request body is required for request on " + request.method + " " + request.url);
+                return Promise.reject(new BodyRequiredError(request.url, request.method));
             }
         }
 

--- a/src/ParamHandler.ts
+++ b/src/ParamHandler.ts
@@ -47,10 +47,10 @@ export class ParamHandler {
         if (param.isRequired) {
             // todo: make better error messages here
             if (param.name && isValueEmpty) {
-                throw new ParameterRequiredError(request.url, request.method, param.name);
+                return Promise.reject(new ParameterRequiredError(request.url, request.method, param.name));
 
             } else if (!param.name && (isValueEmpty || isValueEmptyObject)) {
-                throw new BodyRequiredError(request.url, request.method);
+                return Promise.reject(new BodyRequiredError(request.url, request.method));
             }
         }
 

--- a/src/ParamHandler.ts
+++ b/src/ParamHandler.ts
@@ -1,11 +1,11 @@
+import {ActionCallbackOptions} from "./ActionCallbackOptions";
+import {BodyRequiredError} from "./error/BodyRequiredError";
+import {Driver} from "./driver/Driver";
+import {ParamMetadata} from "./metadata/ParamMetadata";
+import {ParamTypes} from "./metadata/types/ParamTypes";
 import {ParameterParseJsonError} from "./error/ParameterParseJsonError";
 import {ParameterRequiredError} from "./error/ParameterRequiredError";
-import {BodyRequiredError} from "./error/BodyRequiredError";
 import {plainToClass} from "class-transformer";
-import {ParamTypes} from "./metadata/types/ParamTypes";
-import {ParamMetadata} from "./metadata/ParamMetadata";
-import {ActionCallbackOptions} from "./ActionCallbackOptions";
-import {Driver} from "./driver/Driver";
 
 /**
  * Helps to handle parameters.
@@ -47,10 +47,10 @@ export class ParamHandler {
         if (param.isRequired) {
             // todo: make better error messages here
             if (param.name && isValueEmpty) {
-                return Promise.reject(new ParameterRequiredError(request.url, request.method, param.name));
+                throw new ParameterRequiredError(request.url, request.method, param.name);
 
             } else if (!param.name && (isValueEmpty || isValueEmptyObject)) {
-                return Promise.reject(new BodyRequiredError(request.url, request.method));
+                throw new BodyRequiredError(request.url, request.method);
             }
         }
 

--- a/src/driver/KoaDriver.ts
+++ b/src/driver/KoaDriver.ts
@@ -1,17 +1,17 @@
-import {ParamTypes} from "../metadata/types/ParamTypes";
-import {ActionMetadata} from "../metadata/ActionMetadata";
-import {HttpError} from "../error/http/HttpError";
-import {MiddlewareMetadata} from "../metadata/MiddlewareMetadata";
 import {ActionCallbackOptions} from "../ActionCallbackOptions";
-import {BaseDriver} from "./BaseDriver";
-import {classToPlain} from "class-transformer";
+import {ActionMetadata} from "../metadata/ActionMetadata";
 import {BadHttpActionError} from "../error/BadHttpActionError";
+import {BaseDriver} from "./BaseDriver";
 import {Driver} from "./Driver";
-import {UseMetadata} from "../metadata/UseMetadata";
-import {ParamMetadata} from "../metadata/ParamMetadata";
+import {HttpError} from "../error/http/HttpError";
 import {InterceptorMetadata} from "../metadata/InterceptorMetadata";
-import {UseInterceptorMetadata} from "../metadata/UseInterceptorMetadata";
+import {MiddlewareMetadata} from "../metadata/MiddlewareMetadata";
+import {ParamMetadata} from "../metadata/ParamMetadata";
+import {ParamTypes} from "../metadata/types/ParamTypes";
 import {PromiseUtils} from "../util/PromiseUtils";
+import {UseInterceptorMetadata} from "../metadata/UseInterceptorMetadata";
+import {UseMetadata} from "../metadata/UseMetadata";
+import {classToPlain} from "class-transformer";
 const cookie = require("cookie");
 
 /**
@@ -271,7 +271,7 @@ export class KoaDriver extends BaseDriver implements Driver {
             // note that we can't use error instanceof HttpError properly anymore because of new typescript emit process
             if (error.httpCode) {
                 options.context.status = error.httpCode;
-                response.status(error.httpCode);
+                // response.status(error.httpCode);
             } else {
                 options.context.status = 500;
                 // TODO: FIX response.status(500);

--- a/src/driver/KoaDriver.ts
+++ b/src/driver/KoaDriver.ts
@@ -271,7 +271,7 @@ export class KoaDriver extends BaseDriver implements Driver {
             // note that we can't use error instanceof HttpError properly anymore because of new typescript emit process
             if (error.httpCode) {
                 options.context.status = error.httpCode;
-                // response.status(error.httpCode);
+                response.status = error.httpCode;
             } else {
                 options.context.status = 500;
                 // TODO: FIX response.status(500);

--- a/test/functional/action-params.spec.ts
+++ b/test/functional/action-params.spec.ts
@@ -1,24 +1,28 @@
 import "reflect-metadata";
+
 import * as session from "express-session";
-import {Controller} from "../../src/decorator/controllers";
-import {Get, Post} from "../../src/decorator/methods";
-import {UseBefore} from "../../src/decorator/decorators";
-import {createExpressServer, defaultMetadataArgsStorage, createKoaServer} from "../../src/index";
+
 import {
-    Session,
-    Param,
-    QueryParam,
-    HeaderParam,
-    CookieParam,
     Body,
     BodyParam,
+    CookieParam,
+    HeaderParam,
+    Param,
+    QueryParam,
+    Req,
+    Res,
+    Session,
     UploadedFile,
     UploadedFiles,
-    Req,
-    Res
 } from "../../src/decorator/params";
-import {assertRequest} from "./test-utils";
+import {Get, Post} from "../../src/decorator/methods";
+import {createExpressServer, createKoaServer, defaultMetadataArgsStorage} from "../../src/index";
+
+import {Controller} from "../../src/decorator/controllers";
 import {JsonResponse} from "../../src/decorator/decorators";
+import {UseBefore} from "../../src/decorator/decorators";
+import {assertRequest} from "./test-utils";
+
 const chakram = require("chakram");
 const expect = chakram.expect;
 
@@ -339,10 +343,10 @@ describe("action parameters", () => {
             expect(response.body).to.be.equal("<html><body>0</body></html>");
         });
         assertRequest([3001, 3002], "get", "photos-with-required/?", response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
         assertRequest([3001, 3002], "get", "photos-with-required/?limit", response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
     });
 
@@ -388,10 +392,10 @@ describe("action parameters", () => {
             expect(response).to.have.header("content-type", "text/html; charset=utf-8");
         });
         assertRequest([3001, 3002], "get", "posts-with-required", invalidRequestOptions, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
         assertRequest([3001, 3002], "get", "posts-with-required", response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
     });
 
@@ -444,7 +448,7 @@ describe("action parameters", () => {
         });
 
         assertRequest([3001, 3002], "get", "questions-with-required", invalidRequestOptions, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
     });
 
@@ -494,11 +498,11 @@ describe("action parameters", () => {
         });
 
         assertRequest([3001, 3002], "post", "questions-with-required", "", requestOptions, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
 
         assertRequest([3001, 3002], "post", "questions-with-required", undefined, requestOptions, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
     });
 
@@ -516,7 +520,7 @@ describe("action parameters", () => {
             expect(response).to.be.status(200);
         });
         assertRequest([3001, 3002], "post", "posts-with-required", undefined, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
     });
 
@@ -535,19 +539,19 @@ describe("action parameters", () => {
             expect(response).to.be.status(204);
         });
         assertRequest([3001, 3002], "post", "users-with-required", undefined, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
         assertRequest([3001, 3002], "post", "users-with-required", { name: "", age: 27, isActive: false }, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
         assertRequest([3001, 3002], "post", "users-with-required", { name: "Johny", age: 0, isActive: false }, response => {
             expect(response).to.be.status(204);
         });
         assertRequest([3001, 3002], "post", "users-with-required", { name: "Johny", age: undefined, isActive: false }, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
         assertRequest([3001, 3002], "post", "users-with-required", { name: "Johny", age: 27, isActive: undefined }, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
         assertRequest([3001, 3002], "post", "users-with-required", { name: "Johny", age: 27, isActive: false }, response => {
             expect(response).to.be.status(204);
@@ -629,7 +633,7 @@ describe("action parameters", () => {
         });
 
         assertRequest([3001/*, 3002*/], "post", "files-with-required", undefined, {}, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
     });
 
@@ -722,7 +726,7 @@ describe("action parameters", () => {
             expect(response).to.be.status(200);
         });
         assertRequest([3001/*, 3002*/], "post", "photos-with-required", undefined, {}, response => {
-            expect(response).to.be.status(500);
+            expect(response).to.be.status(400);
         });
         
     });


### PR DESCRIPTION
Maybe you could `throw new` instead of `return Promise.reject(new` but I'm not sure whether the exception will be handled or remain uncaught, so I decided to fix it this way.
Fixes #71 

PS: `throw new` is the only correct way