### PR TITLE
swagger.json controller based on metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 typings/
 coverage/
 npm-debug.log
+*.iml
+/.idea/

--- a/src/RoutingControllersOptions.ts
+++ b/src/RoutingControllersOptions.ts
@@ -1,5 +1,6 @@
 import {ClassTransformOptions} from "class-transformer";
 import {ValidationOptions} from "class-validator";
+import {SwaggerOptions} from "./swagger/SwaggerDefinition";
 
 /**
  * Routing controller initialization options.
@@ -88,5 +89,9 @@ export interface RoutingControllersOptions {
      * Route prefix. eg '/api'
      */
     routePrefix?: string;
-    
+
+    /**
+     * Swagger options. By default disabled.
+     */
+    swagger?: SwaggerOptions;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {KoaDriver} from "./driver/KoaDriver";
 import {Driver} from "./driver/Driver";
 import {getFromContainer} from "./container";
 import {RoutingControllersOptions} from "./RoutingControllersOptions";
+import {SwaggerDefinition} from "./swagger/SwaggerDefinition";
 
 // -------------------------------------------------------------------------
 // Main Functions
@@ -98,6 +99,12 @@ function createExecutor(driver: Driver, options: RoutingControllersOptions): voi
 
     if (options.routePrefix !== undefined)
         driver.routePrefix = options.routePrefix;
+
+    if (options && options.swagger && options.swagger.enabled) {
+          new SwaggerDefinition(options.swagger)
+              .bootstrap(options.routePrefix || "/")
+              .controller();
+    }
 
     // next create a controller executor
     new RoutingControllerExecutor(driver)

--- a/src/swagger/SwaggerDefinition.ts
+++ b/src/swagger/SwaggerDefinition.ts
@@ -1,0 +1,165 @@
+import {JsonController, Controller} from "../decorator/controllers";
+import {Get} from "../decorator/methods";
+import {MetadataBuilder} from "../metadata-builder/MetadataBuilder";
+import {UseMetadata} from "../metadata/UseMetadata";
+import {ParamTypes} from "../metadata/types/ParamTypes";
+import {JsonResponse, Header} from "../decorator/decorators";
+import {Res} from "../decorator/params";
+
+export interface SwaggerOptions {
+    /**
+     * Defaults to false
+     */
+    enabled?: boolean;
+    /**
+     * Default value /swagger.json
+     */
+    route?: string;
+
+    /**
+     * Definition basic data
+     */
+    info?: {
+        title?: string;
+        description?: string;
+        termsOfUse?: string;
+        contact?: {
+           name?: string;
+           url?: string;
+           email?: string;
+        }[];
+        license?: string;
+        version?: string;
+    };
+    consumes?: string[];
+    produces?: string[];
+}
+
+/**
+ * Builds and adds a swagger definition controller
+ * Created by Pierre Awaragi on 2017-02-16.
+ */
+export class SwaggerDefinition {
+    private definition: any;
+
+    constructor(private swagger: SwaggerOptions) {
+    }
+
+    /**
+     * Adds a swagger definition controller
+     * @param basePath
+     */
+    public controller() {
+        let definition = this.definition;
+
+        @Controller(this.swagger.route || "/swagger.json")
+        class SwaggerController {
+            @Get()
+            get(): string {
+                return JSON.stringify(definition);
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * builds the swagger definition
+     * @param swagger
+     */
+    bootstrap(basePath: string): SwaggerDefinition {
+        this.definition = {
+            swagger: "2.0",
+            basePath: basePath,
+            paths: this.paths(),
+        };
+        return this;
+    }
+
+    /**
+     * Constructs the paths based on collected metadata
+     * @returns {any}
+     */
+    private paths() {
+        let metadataBuilder: MetadataBuilder = new MetadataBuilder();
+        const middlewares = metadataBuilder.buildMiddlewareMetadata();
+        const interceptors = metadataBuilder.buildInterceptorMetadata();
+        const controllers = metadataBuilder.buildControllerMetadata();
+
+        let paths: any = {};
+        controllers.forEach(controller => {
+            controller.actions.forEach(action => {
+                let i = 0;
+                let route = "" + action.fullRoute;
+
+                if (!paths[route]) {
+                    paths[route] = {};
+                }
+
+                let uses: any = [];
+                action.uses.forEach((useMetada: UseMetadata) => {
+                    if (useMetada.afterAction) {
+                        uses.push(`+${useMetada.middleware.name}`);
+                    } else {
+                        uses.push(`-${useMetada.middleware.name}`);
+                    }
+                });
+                uses.sort();
+                let description = (uses.length > 0 ? (`(${uses.join(", ")})`) : "");
+
+                let empty1: any = [];
+                let empty2: any = [];
+                let type = {
+                    operationId: action.method,
+                    description: description,
+                    // responses: {
+                    //     200: {
+                    //         description: "Success"
+                    //     }
+                    // },
+                    produces: empty1,
+                    parameters: empty2,
+                };
+
+                if (action.jsonResponse || action.isJsonTyped) {
+                    type.produces = ["application/json"];
+                } else if (action.contentTypeHandler && action.contentTypeHandler.value) {
+                    type.produces = [action.contentTypeHandler.value];
+                }
+
+                action.params.forEach(param => {
+                    let typeParameter = {
+                        in: param.type,
+                        name: param.name || null,
+                        type: param.reflectedType.name || null,
+                        required: param.isRequired || false,
+                    };
+                    switch (param.type) {
+                        case ParamTypes.RESPONSE:
+                        case ParamTypes.REQUEST:
+                            typeParameter = null;
+                            break;
+                        case ParamTypes.BODY:
+                            break;
+                        case ParamTypes.UPLOADED_FILE:
+                            typeParameter.type = param.type;
+                            break;
+                        case ParamTypes.UPLOADED_FILES:
+                            delete typeParameter.type;
+                            break;
+                    }
+
+                    if (typeParameter) {
+                        type.parameters.push(typeParameter);
+                    }
+                });
+
+                paths[route][action.type] = type;
+            });
+        });
+
+        return paths;
+    }
+
+
+}

--- a/test/functional/generate-swagger-definition.spec.ts
+++ b/test/functional/generate-swagger-definition.spec.ts
@@ -1,0 +1,233 @@
+import "reflect-metadata";
+import {Controller} from "../../src/decorator/controllers";
+import {Middleware, UseBefore, JsonResponse, ContentType} from "../../src/decorator/decorators";
+import {Get, Post} from "../../src/decorator/methods";
+import {createExpressServer, defaultMetadataArgsStorage, createKoaServer} from "../../src/index";
+import {assertRequest} from "./test-utils";
+import {MiddlewareInterface} from "../../src/middleware/MiddlewareInterface";
+import {Body, Param, QueryParam, UploadedFile, UploadedFiles} from "../../src/decorator/params";
+const chakram = require("chakram");
+const expect = chakram.expect;
+
+/**
+ * Created by Pierre Awaragi on 2017-02-16.
+ */
+describe.only("swagger enabled", () => {
+
+    before(() => {
+
+        // reset metadata args storage
+        defaultMetadataArgsStorage().reset();
+
+        @Middleware()
+        class AuthenticatedMiddelware implements MiddlewareInterface {
+            use(request: any, response: any, next?: (err?: any) => any): any {
+            }
+        }
+
+        @Controller("api")
+        class BasicController {
+            @Get("/get.xml")
+            @ContentType("application/xml")
+            testXmlContentType() {
+            }
+
+            @UseBefore(AuthenticatedMiddelware)
+            @Get("/get.json")
+            @ContentType("application/json")
+            testJsonContentType() {
+            }
+
+            @Get("/get2.json")
+            @JsonResponse()
+            testJsonContentType2() {
+            }
+
+            @Post("/post.empty")
+            testPost() {
+            }
+
+            @Post("/post/body")
+            testPostBody(@Body() body: any) {
+            }
+
+            @Get("/get/:id")
+            testParam(@Param("id") id: number) {
+            }
+
+            @Get("/get/query")
+            testQueryParam(@QueryParam("id") id: string) {
+            }
+
+            @Post("/post/file")
+            testFile(@UploadedFile("file") file: any) {
+            }
+
+            @Post("/post/files")
+            testFiles(@UploadedFiles("files") files: any) {
+            }
+
+        }
+    });
+
+    let expressApp: any, koaApp: any;
+    before(done => expressApp = createExpressServer({swagger: {enabled: true}}).listen(3001, done));
+    after(done => expressApp.close(done));
+
+    describe("get swagger.json expected structure", () => {
+        assertRequest([3001], "get", "swagger.json", response => {
+            expect(response).to.have.status(200);
+            // expect(response).to.have.header("content-type", "application/json; charset=utf-8");
+            let definition = response.body;
+
+            // write swagger file for visual inspection using Swagger UI
+            require("fs").writeFileSync("/tmp/swagger.json", JSON.stringify(response.body));
+
+            expect(definition).to.be.deep.equal( {
+                "swagger": "2.0",
+                "basePath": "/",
+                "paths": {
+                    "api/get.xml": {
+                        "get": {
+                            "operationId": "testXmlContentType",
+                            "description": "",
+                            "produces": [
+                                "application/xml"
+                            ],
+                            "parameters": []
+                        }
+                    },
+                    "api/get.json": {
+                        "get": {
+                            "operationId": "testJsonContentType",
+                            "description": "(-AuthenticatedMiddelware)",
+                            "produces": [
+                                "application/json"
+                            ],
+                            "parameters": []
+                        }
+                    },
+                    "api/get2.json": {
+                        "get": {
+                            "operationId": "testJsonContentType2",
+                            "description": "",
+                            "produces": [
+                                "application/json"
+                            ],
+                            "parameters": []
+                        }
+                    },
+                    "api/post.empty": {
+                        "post": {
+                            "operationId": "testPost",
+                            "description": "",
+                            "produces": [],
+                            "parameters": []
+                        }
+                    },
+                    "api/post/body": {
+                        "post": {
+                            "operationId": "testPostBody",
+                            "description": "",
+                            "produces": [],
+                            "parameters": [
+                                {
+                                    "in": "body",
+                                    "name": null,
+                                    "type": "Object",
+                                    "required": false
+                                }
+                            ]
+                        }
+                    },
+                    "api/get/:id": {
+                        "get": {
+                            "operationId": "testParam",
+                            "description": "",
+                            "produces": [],
+                            "parameters": [
+                                {
+                                    "in": "param",
+                                    "name": "id",
+                                    "type": "Number",
+                                    "required": true
+                                }
+                            ]
+                        }
+                    },
+                    "api/get/query": {
+                        "get": {
+                            "operationId": "testQueryParam",
+                            "description": "",
+                            "produces": [],
+                            "parameters": [
+                                {
+                                    "in": "query",
+                                    "name": "id",
+                                    "type": "String",
+                                    "required": false
+                                }
+                            ]
+                        }
+                    },
+                    "api/post/file": {
+                        "post": {
+                            "operationId": "testFile",
+                            "description": "",
+                            "produces": [],
+                            "parameters": [
+                                {
+                                    "in": "file",
+                                    "name": "file",
+                                    "type": "file",
+                                    "required": false
+                                }
+                            ]
+                        }
+                    },
+                    "api/post/files": {
+                        "post": {
+                            "operationId": "testFiles",
+                            "description": "",
+                            "produces": [],
+                            "parameters": [
+                                {
+                                    "in": "files",
+                                    "name": "files",
+                                    "required": false
+                                }
+                            ]
+                        }
+                    }
+                }
+            });
+        });
+    });
+});
+
+describe("swagger disabled", () => {
+
+    before(() => {
+        // reset metadata args storage
+        defaultMetadataArgsStorage().reset();
+
+        @Controller("/basic")
+        class BasicController {
+            @Get()
+            get() {
+            }
+        }
+    });
+
+    let expressApp: any, koaApp: any;
+    before(done => expressApp = createExpressServer().listen(3001, done));
+    after(done => expressApp.close(done));
+    before(done => koaApp = createKoaServer().listen(3002, done));
+    after(done => koaApp.close(done));
+
+    describe("get swagger.json expected to fail", () => {
+        assertRequest([3001, 3002], "get", "swagger.json", response => {
+            expect(response).to.have.status(404);
+        });
+    });
+});


### PR DESCRIPTION
This is a quick draft of swagger definition generator based on currently collected metadata
remains to do
- basic info section
- add @Api and other tags as per swagger annotation project (https://github.com/swagger-api/swagger-core/wiki/Annotations-1.5.X)
- add documentation

Please let me know if this is of interest. The swagger specific annotations can be done separately but I believe the framework can greatly benefit from swagger definition right next to controllers definitions all bundled together.