### PR TITLE
Remove reference to loadControllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ You can load all controllers in once from specific directories, by specifying ar
 
 ```typescript
 import "reflect-metadata"; // this shim is required
-import {createExpressServer, loadControllers} from "routing-controllers";
+import {createExpressServer} from "routing-controllers";
 
 createExpressServer({
     controllers: [__dirname + "/controllers/*.js"]
@@ -922,7 +922,7 @@ Also you can load middlewares from directories. Also you can use glob patterns:
 
 ```typescript
 import "reflect-metadata";
-import {createExpressServer, loadControllers} from "routing-controllers";
+import {createExpressServer} from "routing-controllers";
 createExpressServer({
     controllers: [__dirname + "/controllers/**/*.js"],
     middlewares: [__dirname + "/middlewares/**/*.js"]


### PR DESCRIPTION
Getting an error about loadControllers:
```
server-typestack (master<>)$ tsc
src/app-typestack.ts(2,26): error TS2305: Module '"/Users/bencreasy/code/projects/starters/react-redux-typescript-starter-kit/node_modules/routing-controllers/index"' has no exported member 'loadControllers'.
```
Also a search shows no evidence of a loadControllers function: https://github.com/pleerock/routing-controllers/search?utf8=%E2%9C%93&q=loadControllers