### PR TITLE
Fix routePrefix handling for routes using regex

### DIFF
--- a/src/metadata/ActionMetadata.ts
+++ b/src/metadata/ActionMetadata.ts
@@ -262,11 +262,15 @@ export class ActionMetadata {
      * Appends base route to a given regexp route.
      */
     static appendBaseRoute(baseRoute: string, route: RegExp|string) {
+        const prefix = `${baseRoute.length > 0 && baseRoute.indexOf("/") < 0 ? "/" : ""}${baseRoute}`;
+
         if (typeof route === "string")
-            return `${baseRoute}${route}`;
+            return `${prefix}${route}`;
 
         if (!baseRoute || baseRoute === "") return route;
-        const fullPath = baseRoute.replace("\/", "\\\\/") + route.toString().substr(1);
+
+        const fullPath = `^${prefix}${route.toString().substr(1)}?$`;
+        
         return new RegExp(fullPath, route.flags);
     }
     


### PR DESCRIPTION
Routes using regex had some issues:

- They didn't work when `routePrefix` was provided starting with `/`
- The did work if `/` was omitted from `routePrefix`, but then all other routes started failing

The following changes were made to target this issue:

- Changed the way the full route path was created at `ActionMetadata` to match the resulting regex pattern with those routes created without regex usage.
- Added missing tests for regex routes for an an app that sets the `routePrefix` param