### PR TITLE
Reduce the number of get access calls and improve performance.

### DIFF
--- a/src/driver/ExpressDriver.ts
+++ b/src/driver/ExpressDriver.ts
@@ -61,12 +61,13 @@ export class ExpressDriver extends BaseDriver implements Driver {
      * Registers middleware that run before controller actions.
      */
     registerMiddleware(middleware: MiddlewareMetadata): void {
-        if (!middleware.instance.use)
+        const instance = middleware.instance;
+        if (!instance.use)
             return;
 
         this.express.use((request: any, response: any, next: (err: any) => any) => {
             try {
-                const useResult = middleware.instance.use(request, response, next);
+                const useResult = instance.use(request, response, next);
                 if (useResult instanceof Promise) {
                     useResult.catch((error: any) => {
                         this.handleError(error, undefined, {
@@ -105,8 +106,9 @@ export class ExpressDriver extends BaseDriver implements Driver {
             .sort((interceptor1, interceptor2) => interceptor1.priority - interceptor2.priority)
             .reverse()
             .map(interceptor => {
+                const instance = interceptor.instance;
                 return function (request: any, response: any, result: any) {
-                    return interceptor.instance.intercept(request, response, result);
+                    return instance.intercept(request, response, result);
                 };
             });
 
@@ -312,9 +314,10 @@ export class ExpressDriver extends BaseDriver implements Driver {
         useInterceptors.forEach(useInterceptor => {
             if (useInterceptor.interceptor.prototype && useInterceptor.interceptor.prototype.intercept) { // if this is function instance of MiddlewareInterface
                 interceptors.forEach(interceptor => {
+                    const instance = interceptor.instance;
                     if (interceptor.instance instanceof useInterceptor.interceptor) {
                         interceptFunctions.push(function (request: any, response: any, result: any) {
-                            return interceptor.instance.intercept(request, response, result);
+                            return instance.intercept(request, response, result);
                         });
                     }
                 });
@@ -331,9 +334,10 @@ export class ExpressDriver extends BaseDriver implements Driver {
         uses.forEach(use => {
             if (use.middleware.prototype && use.middleware.prototype.use) { // if this is function instance of MiddlewareInterface
                 middlewares.forEach(middleware => {
-                    if (middleware.instance instanceof use.middleware) {
+                    const instance = middleware.instance;
+                    if (instance instanceof use.middleware) {
                         middlewareFunctions.push(function (request: any, response: any, next: (err: any) => any) {
-                            return middleware.instance.use(request, response, next);
+                            return instance.use(request, response, next);
                         });
                     }
                 });

--- a/src/driver/KoaDriver.ts
+++ b/src/driver/KoaDriver.ts
@@ -64,11 +64,12 @@ export class KoaDriver extends BaseDriver implements Driver {
     }
 
     registerMiddleware(middleware: MiddlewareMetadata): void {
-        if (!middleware.instance.use)
+        const instance = middleware.instance;
+        if (!instance.use)
             return;
         
         this.koa.use(function (ctx: any, next: any) {
-            return middleware.instance.use(ctx, next);
+            return instance.use(ctx, next);
         });
     }
 
@@ -87,8 +88,9 @@ export class KoaDriver extends BaseDriver implements Driver {
             .sort((interceptor1, interceptor2) => interceptor1.priority - interceptor2.priority)
             .reverse()
             .map(interceptor => {
+                const instance = interceptor.instance;
                 return function (request: any, response: any, result: any) {
-                    return interceptor.instance.intercept(request, response, result);
+                    return instance.intercept(request, response, result);
                 };
             });
 
@@ -307,9 +309,10 @@ export class KoaDriver extends BaseDriver implements Driver {
         useInterceptors.forEach(useInterceptor => {
             if (useInterceptor.interceptor.prototype && useInterceptor.interceptor.prototype.intercept) { // if this is function instance of MiddlewareInterface
                 interceptors.forEach(interceptor => {
-                    if (interceptor.instance instanceof useInterceptor.interceptor) {
+                    const instance = interceptor.instance;
+                    if (instance instanceof useInterceptor.interceptor) {
                         interceptFunctions.push(function (request: any, response: any, result: any) {
-                            return interceptor.instance.intercept(request, response, result);
+                            return instance.intercept(request, response, result);
                         });
                     }
                 });
@@ -326,9 +329,10 @@ export class KoaDriver extends BaseDriver implements Driver {
         uses.forEach(use => {
             if (use.middleware.prototype && use.middleware.prototype.use) { // if this is function instance of MiddlewareInterface
                 middlewares.forEach(middleware => {
-                    if (middleware.instance instanceof use.middleware) {
+                    const instance = middleware.instance;
+                    if (instance instanceof use.middleware) {
                         middlewareFunctions.push(function(context: any, next: Function) {
-                            return middleware.instance.use(context, next);
+                            return instance.use(context, next);
                         });
                     }
                 });

--- a/src/metadata/ActionMetadata.ts
+++ b/src/metadata/ActionMetadata.ts
@@ -21,6 +21,11 @@ export class ActionMetadata {
     controllerMetadata: ControllerMetadata;
 
     /**
+     * Action's instance.
+     */
+     instance: any;
+
+    /**
      * Action's parameters.
      */
     params: ParamMetadata[];
@@ -67,7 +72,7 @@ export class ActionMetadata {
     
     constructor(controllerMetadata: ControllerMetadata, args: ActionMetadataArgs) {
         this.controllerMetadata = controllerMetadata;
-        
+        this.instance = controllerMetadata.instance;
         if (args.route)
             this.route = args.route;
         if (args.target)
@@ -247,7 +252,7 @@ export class ActionMetadata {
     // -------------------------------------------------------------------------
 
     executeAction(params: any[]) {
-        return this.controllerMetadata.instance[this.method].apply(this.controllerMetadata.instance, params);
+        return this.instance[this.method].apply(this.instance, params);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Because each call get accessor, will be obtained from the container, which is unnecessary.