### PR TITLE
allow default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can use routing-controllers with [express.js][1] or [koa.js][2].
       - [Render templates](#render-templates)
       - [Throw HTTP errors](#throw-http-errors)
       - [Enable CORS](#enable-cors)
+      - [Default settings](#default-settings)
   * [Using middlewares](#using-middlewares)
     + [Use exist middleware](#use-exist-middleware)
     + [Creating your own express middleware](#creating-your-own-express-middleware)
@@ -723,6 +724,34 @@ const app = createExpressServer({
         // options from cors documentation
     },
     controllers: [UserController]
+});
+
+app.listen(3000);
+```
+
+#### Default settings
+
+You can override default status code in routing-controllers options. 
+
+```typescript
+import "reflect-metadata";
+import {createExpressServer} from "routing-controllers";
+import {UserController} from "./UserController";
+
+const app = createExpressServer({
+    defaults: {
+
+        //with this option, null will return 404 by default
+        nullResultCode: 404,
+
+        //with this option, void or Promise<void> will return 204 by default 
+        undefinedResultCode: 204,
+        
+        paramOptions: {
+            //with this option, argument will be required by default
+            required: true
+        }
+    }
 });
 
 app.listen(3000);

--- a/src/RoutingControllers.ts
+++ b/src/RoutingControllers.ts
@@ -1,13 +1,14 @@
-import {ActionParameterHandler} from "./ActionParameterHandler";
-import {MetadataBuilder} from "./metadata-builder/MetadataBuilder";
-import {ActionMetadata} from "./metadata/ActionMetadata";
 import {Action} from "./Action";
+import {ActionMetadata} from "./metadata/ActionMetadata";
+import {ActionParameterHandler} from "./ActionParameterHandler";
 import {Driver} from "./driver/Driver";
+import {InterceptorInterface} from "./InterceptorInterface";
+import {InterceptorMetadata} from "./metadata/InterceptorMetadata";
+import {MetadataBuilder} from "./metadata-builder/MetadataBuilder";
+import { RoutingControllersOptions } from "./RoutingControllersOptions";
+import {getFromContainer} from "./container";
 import {isPromiseLike} from "./util/isPromiseLike";
 import {runInSequence} from "./util/runInSequence";
-import {InterceptorMetadata} from "./metadata/InterceptorMetadata";
-import {getFromContainer} from "./container";
-import {InterceptorInterface} from "./InterceptorInterface";
 
 /**
  * Registers controllers and middlewares in the given server framework.
@@ -37,9 +38,9 @@ export class RoutingControllers {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(private driver: Driver) {
+    constructor(private driver: Driver, private options: RoutingControllersOptions) {
         this.parameterHandler = new ActionParameterHandler(driver);
-        this.metadataBuilder = new MetadataBuilder();
+        this.metadataBuilder = new MetadataBuilder(options);
     }
 
     // -------------------------------------------------------------------------

--- a/src/RoutingControllersOptions.ts
+++ b/src/RoutingControllersOptions.ts
@@ -91,12 +91,12 @@ export interface RoutingControllersOptions {
      */
     defaults?: {
         /**
-         * If set, all null response will return specified status code by default
+         * If set, all null responses will return specified status code by default
          */
         nullResultCode?: number;
 
         /**
-         * If set, all undefined response will return specified status code by default
+         * If set, all undefined responses will return specified status code by default
          */
         undefinedResultCode?: number;
 

--- a/src/RoutingControllersOptions.ts
+++ b/src/RoutingControllersOptions.ts
@@ -1,7 +1,8 @@
-import {ClassTransformOptions} from "class-transformer";
-import {ValidatorOptions} from "class-validator";
 import {AuthorizationChecker} from "./AuthorizationChecker";
+import {ClassTransformOptions} from "class-transformer";
 import {CurrentUserChecker} from "./CurrentUserChecker";
+import { ParamOptions } from "./decorator-options/ParamOptions";
+import {ValidatorOptions} from "class-validator";
 
 /**
  * Routing controller initialization options.
@@ -85,4 +86,28 @@ export interface RoutingControllersOptions {
      */
     currentUserChecker?: CurrentUserChecker;
     
+    /**
+     * Default settings
+     */
+    defaults?: {
+        /**
+         * If set, all null response will return specified status code by default
+         */
+        nullResultCode?: number;
+
+        /**
+         * If set, all undefined response will return specified status code by default
+         */
+        undefinedResultCode?: number;
+
+        /**
+         * Default param options
+         */
+        paramOptions?: {
+            /**
+             * If true, all non-set parameters will be required by default
+             */
+            required?: boolean;
+        };
+    };
 }

--- a/src/decorator/Body.ts
+++ b/src/decorator/Body.ts
@@ -13,7 +13,7 @@ export function Body(options?: BodyOptions): Function {
             method: methodName,
             index: index,
             parse: false,
-            required: options ? options.required : false,
+            required: options ? options.required : undefined,
             classTransform: options ? options.transform : undefined,
             validate: options ? options.validate : undefined,
             explicitType: options ? options.type : undefined,

--- a/src/decorator/BodyParam.ts
+++ b/src/decorator/BodyParam.ts
@@ -1,5 +1,5 @@
-import {getMetadataArgsStorage} from "../index";
 import {ParamOptions} from "../decorator-options/ParamOptions";
+import {getMetadataArgsStorage} from "../index";
 
 /**
  * Takes partial data of the request body.
@@ -14,7 +14,7 @@ export function BodyParam(name: string, options?: ParamOptions): Function {
             index: index,
             name: name,
             parse: options ? options.parse : false,
-            required: options ? options.required : false,
+            required: options ? options.required : undefined,
             explicitType: options ? options.type : undefined,
             classTransform: options ? options.transform : undefined,
             validate: options ? options.validate : undefined

--- a/src/decorator/CookieParam.ts
+++ b/src/decorator/CookieParam.ts
@@ -1,5 +1,5 @@
-import {getMetadataArgsStorage} from "../index";
 import {ParamOptions} from "../decorator-options/ParamOptions";
+import {getMetadataArgsStorage} from "../index";
 
 /**
  * Injects a request's cookie value to the controller action parameter.
@@ -14,7 +14,7 @@ export function CookieParam(name: string, options?: ParamOptions) {
             index: index,
             name: name,
             parse: options ? options.parse : false,
-            required: options ? options.required : false,
+            required: options ? options.required : undefined,
             explicitType: options ? options.type : undefined,
             classTransform: options ? options.transform : undefined,
             validate: options ? options.validate : undefined

--- a/src/decorator/CurrentUser.ts
+++ b/src/decorator/CurrentUser.ts
@@ -12,7 +12,7 @@ export function CurrentUser(options?: { required?: boolean }) {
             method: methodName,
             index: index,
             parse: false,
-            required: options ? options.required : false
+            required: options ? options.required : undefined
         });
     };
 }

--- a/src/decorator/HeaderParam.ts
+++ b/src/decorator/HeaderParam.ts
@@ -1,5 +1,5 @@
-import {getMetadataArgsStorage} from "../index";
 import {ParamOptions} from "../decorator-options/ParamOptions";
+import {getMetadataArgsStorage} from "../index";
 
 /**
  * Injects a request's http header value to the controller action parameter.
@@ -14,7 +14,7 @@ export function HeaderParam(name: string, options?: ParamOptions): Function {
             index: index,
             name: name,
             parse: options ? options.parse : false,
-            required: options ? options.required : false,
+            required: options ? options.required : undefined,
             classTransform: options ? options.transform : undefined,
             explicitType: options ? options.type : undefined,
             validate: options ? options.validate : undefined

--- a/src/decorator/QueryParam.ts
+++ b/src/decorator/QueryParam.ts
@@ -1,5 +1,5 @@
-import {getMetadataArgsStorage} from "../index";
 import {ParamOptions} from "../decorator-options/ParamOptions";
+import {getMetadataArgsStorage} from "../index";
 
 /**
  * Injects a request's query parameter value to the controller action parameter.
@@ -14,7 +14,7 @@ export function QueryParam(name: string, options?: ParamOptions): Function {
             index: index,
             name: name,
             parse: options ? options.parse : false,
-            required: options ? options.required : false,
+            required: options ? options.required : undefined,
             classTransform: options ? options.transform : undefined,
             explicitType: options ? options.type : undefined,
             validate: options ? options.validate : undefined

--- a/src/decorator/Session.ts
+++ b/src/decorator/Session.ts
@@ -30,7 +30,7 @@ export function Session(optionsOrObjectName?: ParamOptions|string, paramOptions?
             index: index,
             name: propertyName,
             parse: false, // it makes no sense for Session object to be parsed as json
-            required: options.required,
+            required: options.required !== undefined ? options.required : true,
             classTransform: options.transform,
             validate: options.validate !== undefined ? options.validate : false,
         });

--- a/src/decorator/Session.ts
+++ b/src/decorator/Session.ts
@@ -1,6 +1,5 @@
-import { getMetadataArgsStorage } from "../index";
 import { ParamOptions } from "../decorator-options/ParamOptions";
-
+import { getMetadataArgsStorage } from "../index";
 
 /**
  * Injects a Session object to the controller action parameter.
@@ -31,7 +30,7 @@ export function Session(optionsOrObjectName?: ParamOptions|string, paramOptions?
             index: index,
             name: propertyName,
             parse: false, // it makes no sense for Session object to be parsed as json
-            required: options.required !== undefined ? options.required : true,
+            required: options.required,
             classTransform: options.transform,
             validate: options.validate !== undefined ? options.validate : false,
         });

--- a/src/decorator/UploadedFile.ts
+++ b/src/decorator/UploadedFile.ts
@@ -1,5 +1,5 @@
-import {getMetadataArgsStorage} from "../index";
 import {UploadOptions} from "../decorator-options/UploadOptions";
+import {getMetadataArgsStorage} from "../index";
 
 /**
  * Injects an uploaded file object to the controller action parameter.
@@ -14,7 +14,7 @@ export function UploadedFile(name: string, options?: UploadOptions): Function {
             index: index,
             name: name,
             parse: false,
-            required: options ? options.required : false,
+            required: options ? options.required : undefined,
             extraOptions: options ? options.options : undefined
         });
     };

--- a/src/decorator/UploadedFiles.ts
+++ b/src/decorator/UploadedFiles.ts
@@ -1,5 +1,5 @@
-import {getMetadataArgsStorage} from "../index";
 import {UploadOptions} from "../decorator-options/UploadOptions";
+import {getMetadataArgsStorage} from "../index";
 
 /**
  * Injects all uploaded files to the controller action parameter.
@@ -14,7 +14,7 @@ export function UploadedFiles(name: string, options?: UploadOptions): Function {
             index: index,
             name: name,
             parse: false,
-            required: options ? options.required : false,
+            required: options ? options.required : undefined,
             extraOptions: options ? options.options : undefined
         });
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import {importClassesFromDirectories} from "./util/importClassesFromDirectories";
-import {RoutingControllers} from "./RoutingControllers";
+import {CustomParameterDecorator} from "./CustomParameterDecorator";
+import {Driver} from "./driver/Driver";
 import {ExpressDriver} from "./driver/express/ExpressDriver";
 import {KoaDriver} from "./driver/koa/KoaDriver";
-import {Driver} from "./driver/Driver";
-import {RoutingControllersOptions} from "./RoutingControllersOptions";
-import {CustomParameterDecorator} from "./CustomParameterDecorator";
 import {MetadataArgsStorage} from "./metadata-builder/MetadataArgsStorage";
+import {RoutingControllers} from "./RoutingControllers";
+import {RoutingControllersOptions} from "./RoutingControllersOptions";
 import {ValidationOptions} from "class-validator";
+import {importClassesFromDirectories} from "./util/importClassesFromDirectories";
 
 // -------------------------------------------------------------------------
 // Main exports
@@ -207,7 +207,7 @@ function createExecutor(driver: Driver, options: RoutingControllersOptions): voi
     driver.cors = options.cors;
 
     // next create a controller executor
-    new RoutingControllers(driver)
+    new RoutingControllers(driver, options)
         .initialize()
         .registerInterceptors(interceptorClasses)
         .registerMiddlewares("before")

--- a/src/metadata/ActionMetadata.ts
+++ b/src/metadata/ActionMetadata.ts
@@ -1,12 +1,13 @@
-import {ParamMetadata} from "./ParamMetadata";
+import {Action} from "../Action";
 import {ActionMetadataArgs} from "./args/ActionMetadataArgs";
 import {ActionType} from "./types/ActionType";
-import {ControllerMetadata} from "./ControllerMetadata";
-import {ResponseHandlerMetadata} from "./ResponseHandleMetadata";
-import {UseMetadata} from "./UseMetadata";
 import {ClassTransformOptions} from "class-transformer";
-import {Action} from "../Action";
+import {ControllerMetadata} from "./ControllerMetadata";
 import {InterceptorMetadata} from "./InterceptorMetadata";
+import {ParamMetadata} from "./ParamMetadata";
+import {ResponseHandlerMetadata} from "./ResponseHandleMetadata";
+import { RoutingControllersOptions } from "../RoutingControllersOptions";
+import {UseMetadata} from "./UseMetadata";
 
 /**
  * Action metadata.
@@ -147,7 +148,7 @@ export class ActionMetadata {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(controllerMetadata: ControllerMetadata, args: ActionMetadataArgs) {
+    constructor(controllerMetadata: ControllerMetadata, args: ActionMetadataArgs, private options: RoutingControllersOptions) {
         this.controllerMetadata = controllerMetadata;
         this.route = args.route;
         this.target = args.target;
@@ -177,10 +178,15 @@ export class ActionMetadata {
 
         if (classTransformerResponseHandler)
             this.responseClassTransformOptions = classTransformerResponseHandler.value;
-        if (undefinedResultHandler)
-            this.undefinedResultCode = undefinedResultHandler.value;
-        if (nullResultHandler)
-            this.nullResultCode = nullResultHandler.value;
+        
+        this.undefinedResultCode = undefinedResultHandler
+            ? undefinedResultHandler.value
+            : this.options.defaults && this.options.defaults.undefinedResultCode;
+        
+        this.nullResultCode = nullResultHandler
+            ? nullResultHandler.value
+            : this.options.defaults && this.options.defaults.nullResultCode;
+        
         if (successCodeHandler)
             this.successHttpCode = successCodeHandler.value;
         if (redirectHandler)

--- a/test/functional/defaults.spec.ts
+++ b/test/functional/defaults.spec.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import {createExpressServer, getMetadataArgsStorage} from "../../src/index";
+import { createExpressServer, getMetadataArgsStorage, createKoaServer } from '../../src/index';
 import {ExpressMiddlewareInterface} from "../../src/driver/express/ExpressMiddlewareInterface";
 import {Controller} from "../../src/decorator/Controller";
 import {Get} from "../../src/decorator/Get";
@@ -10,10 +10,11 @@ import {NotAcceptableError} from "./../../src/http-error/NotAcceptableError";
 import {ExpressErrorMiddlewareInterface} from "./../../src/driver/express/ExpressErrorMiddlewareInterface";
 import { QueryParam } from '../../src/decorator/QueryParam';
 import { OnUndefined } from '../../src/decorator/OnUndefined';
+import { assertRequest } from './test-utils';
 const chakram = require("chakram");
 const expect = chakram.expect;
 
-describe("express middlewares", () => {
+describe("defaults", () => {
 
     before(() => {
 
@@ -54,8 +55,9 @@ describe("express middlewares", () => {
 
     let defaultUndefinedResultCode = 204;
     let defaultNullResultCode = 404;
-    let app: any;
-    before(done => app = createExpressServer({
+    let expressApp: any;
+    let kuaApp: any;
+    before(done => expressApp = createExpressServer({
         defaults: {
             nullResultCode: defaultNullResultCode,
             undefinedResultCode: defaultUndefinedResultCode,
@@ -64,36 +66,52 @@ describe("express middlewares", () => {
             }
         }
     }).listen(3001, done));
-    after(done => app.close(done));
+    before(done => kuaApp = createKoaServer({
+        defaults: {
+            nullResultCode: defaultNullResultCode,
+            undefinedResultCode: defaultUndefinedResultCode,
+            paramOptions: {
+                required: true
+            }
+        }
+    }).listen(3002, done));
+    after(done => expressApp.close(done));
+    after(done => kuaApp.close(done));
 
-    it("should return undefinedResultCode from defaults config for void function", async () => {
-        let res = await chakram.get("http://127.0.0.1:3001/voidfunc");
-        expect(res).to.have.status(defaultUndefinedResultCode);
+    it("should return undefinedResultCode from defaults config for void function", () => {
+        assertRequest([3001, 3002], 'get', 'voidfunc', res => {
+            expect(res).to.have.status(defaultUndefinedResultCode);
+        });
     });
 
-    it("should return undefinedResultCode from defaults config for promise void function", async () => {
-        let res = await chakram.get("http://127.0.0.1:3001/promisevoidfunc");
-        expect(res).to.have.status(defaultUndefinedResultCode);
+    it("should return undefinedResultCode from defaults config for promise void function", () => {
+        assertRequest([3001, 3002], 'get', 'promisevoidfunc', res => {
+            expect(res).to.have.status(defaultUndefinedResultCode);
+        });
     });
 
-    it("should return 400 from required paramOptions", async () => {
-        let res = await chakram.get("http://127.0.0.1:3001/paramfunc");
-        expect(res).to.have.status(400);
+    it("should return 400 from required paramOptions", () => {
+        assertRequest([3001, 3002], 'get', 'paramfunc', res => {
+            expect(res).to.have.status(400);
+        });
     });
 
-    it("should return nullResultCode from defaults config", async () => {
-        let res = await chakram.get("http://127.0.0.1:3001/nullfunc");
-        expect(res).to.have.status(defaultNullResultCode);
+    it("should return nullResultCode from defaults config", () => {
+        assertRequest([3001, 3002], 'get', 'nullfunc', res => {
+            expect(res).to.have.status(defaultNullResultCode);
+        });
     });
 
-    it("should return status code from OnUndefined annotation", async () => {
-        let res = await chakram.get("http://127.0.0.1:3001/overridefunc");
-        expect(res).to.have.status(404);
+    it("should return status code from OnUndefined annotation", () => {
+        assertRequest([3001, 3002], 'get', 'overridefunc', res => {
+            expect(res).to.have.status(404);
+        });
     });
 
-    it("should mark arg optional from QueryParam annotation", async () => {
-        let res = await chakram.get("http://127.0.0.1:3001/overrideparamfunc");
-        expect(res).to.have.status(200);
+    it("should mark arg optional from QueryParam annotation", () => {
+        assertRequest([3001, 3002], 'get', 'overrideparamfunc', res => {
+            expect(res).to.have.status(200);
+        });
     });
 
 });

--- a/test/functional/express-defaults.spec.ts
+++ b/test/functional/express-defaults.spec.ts
@@ -1,0 +1,99 @@
+import "reflect-metadata";
+import {createExpressServer, getMetadataArgsStorage} from "../../src/index";
+import {ExpressMiddlewareInterface} from "../../src/driver/express/ExpressMiddlewareInterface";
+import {Controller} from "../../src/decorator/Controller";
+import {Get} from "../../src/decorator/Get";
+import {UseBefore} from "../../src/decorator/UseBefore";
+import {Middleware} from "../../src/decorator/Middleware";
+import {UseAfter} from "../../src/decorator/UseAfter";
+import {NotAcceptableError} from "./../../src/http-error/NotAcceptableError";
+import {ExpressErrorMiddlewareInterface} from "./../../src/driver/express/ExpressErrorMiddlewareInterface";
+import { QueryParam } from '../../src/decorator/QueryParam';
+import { OnUndefined } from '../../src/decorator/OnUndefined';
+const chakram = require("chakram");
+const expect = chakram.expect;
+
+describe("express middlewares", () => {
+
+    before(() => {
+
+        // reset metadata args storage
+        getMetadataArgsStorage().reset();
+
+        @Controller()
+        class ExpressController {
+
+            @Get("/voidfunc")
+            voidfunc() { }
+
+            @Get("/promisevoidfunc")
+            promisevoidfunc() {
+                return Promise.resolve();
+            }
+
+            @Get("/paramfunc")
+            paramfunc(@QueryParam('x') x: number) {
+                return { foo: 'bar' };
+            }
+
+            @Get("/nullfunc")
+            nullfunc(): string {
+                return null;
+            }
+
+            @Get("/overridefunc")
+            @OnUndefined(404)
+            overridefunc() { }
+
+            @Get("/overrideparamfunc")
+            overrideparamfunc(@QueryParam('x', { required: false }) x: number) {
+                return { foo: 'bar' };
+            }
+        }
+    });
+
+    let defaultUndefinedResultCode = 204;
+    let defaultNullResultCode = 404;
+    let app: any;
+    before(done => app = createExpressServer({
+        defaults: {
+            nullResultCode: defaultNullResultCode,
+            undefinedResultCode: defaultUndefinedResultCode,
+            paramOptions: {
+                required: true
+            }
+        }
+    }).listen(3001, done));
+    after(done => app.close(done));
+
+    it("should return undefinedResultCode from defaults config for void function", async () => {
+        let res = await chakram.get("http://127.0.0.1:3001/voidfunc");
+        expect(res).to.have.status(defaultUndefinedResultCode);
+    });
+
+    it("should return undefinedResultCode from defaults config for promise void function", async () => {
+        let res = await chakram.get("http://127.0.0.1:3001/promisevoidfunc");
+        expect(res).to.have.status(defaultUndefinedResultCode);
+    });
+
+    it("should return 400 from required paramOptions", async () => {
+        let res = await chakram.get("http://127.0.0.1:3001/paramfunc");
+        expect(res).to.have.status(400);
+    });
+
+    it("should return nullResultCode from defaults config", async () => {
+        let res = await chakram.get("http://127.0.0.1:3001/nullfunc");
+        expect(res).to.have.status(defaultNullResultCode);
+    });
+
+    it("should return status code from OnUndefined annotation", async () => {
+        let res = await chakram.get("http://127.0.0.1:3001/overridefunc");
+        expect(res).to.have.status(404);
+    });
+
+    it("should mark arg optional from QueryParam annotation", async () => {
+        let res = await chakram.get("http://127.0.0.1:3001/overrideparamfunc");
+        expect(res).to.have.status(200);
+    });
+
+});


### PR DESCRIPTION
Hi @pleerock,


Your library is great. And I think it would be better if we are able to set default values.

For example, if method is `void` or `Promise<void>`, I expected it to return `204` rather than `404` by default. If there is any exception, then I will override by `OnUndefined` decorator.

The other setting I prefer to set is `required` option, I want all parameters to required by default. And I can override with the param options.

This would give more flexibility to other projects which have different convention, and improve readability since there is less number of settings needed to be specified.

Thank you,
