### PR TITLE
Add @Fallthrough() decorator and global option to enable route fallthrough, which is now off by default

### DIFF
--- a/src/RoutingControllersOptions.ts
+++ b/src/RoutingControllersOptions.ts
@@ -20,6 +20,11 @@ export interface RoutingControllersOptions {
     routePrefix?: string;
 
     /**
+     * Enable automatic fallthrough from action handlers to future actions or middleware
+     */
+    automaticFallthrough?: boolean;
+
+    /**
      * List of controllers to register in the framework or directories from where to import all your controllers.
      */
     controllers?: Function[]|string[];

--- a/src/decorator/Fallthrough.ts
+++ b/src/decorator/Fallthrough.ts
@@ -1,0 +1,15 @@
+import {getMetadataArgsStorage} from "../index";
+
+/**
+ * Indicates that this route should fall through to further route handlers or middleware after being executed.
+ * This is equivalent to a route handler calling next() with no parameters in Express.
+ */
+export function Fallthrough(): Function {
+    return function (object: Object, methodName: string) {
+        getMetadataArgsStorage().responseHandlers.push({
+            type: "fallthrough",
+            target: object.constructor,
+            method: methodName
+        });
+    };
+}

--- a/src/driver/BaseDriver.ts
+++ b/src/driver/BaseDriver.ts
@@ -56,6 +56,11 @@ export class BaseDriver {
     routePrefix: string = "";
 
     /**
+     * Enable automatic fallthrough from action handlers to future actions or middleware
+     */
+    automaticFallthrough: boolean;
+
+    /**
      * Indicates if cors are enabled.
      * This requires installation of additional module (cors for express and kcors for koa).
      */

--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -60,6 +60,11 @@ export interface Driver {
     routePrefix: string;
 
     /**
+     * Enable automatic fallthrough from action handlers to future actions or middleware
+     */
+    automaticFallthrough: boolean;
+
+    /**
      * Indicates if cors are enabled.
      * This requires installation of additional module (cors for express and kcors for koa).
      */

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -258,7 +258,8 @@ export class ExpressDriver extends BaseDriver implements Driver {
                 options.response.redirect(action.redirect);
             }
 
-            options.next();
+            if (this.automaticFallthrough || action.fallthrough)
+                options.next();
 
         } else if (action.renderedTemplate) { // if template is set then render it
             const renderOptions = result && result instanceof Object ? result : {};
@@ -273,7 +274,9 @@ export class ExpressDriver extends BaseDriver implements Driver {
                 } else if (html) {
                     options.response.send(html);
                 }
-                options.next();
+
+                if (this.automaticFallthrough || action.fallthrough)
+                    options.next();
             });
 
         } else if (result !== undefined || action.undefinedResultCode) { // send regular result
@@ -287,18 +290,21 @@ export class ExpressDriver extends BaseDriver implements Driver {
                 } else {
                     options.response.send();
                 }
-                options.next();
+                if (this.automaticFallthrough || action.fallthrough)
+                    options.next();
             } else {
                 if (action.isJsonTyped) {
                     options.response.json(result);
                 } else {
                     options.response.send(result);
                 }
-                options.next();
+                if (this.automaticFallthrough || action.fallthrough)
+                    options.next();
             }
 
         } else {
-            options.next();
+            if (this.automaticFallthrough || action.fallthrough)
+                options.next();
         }
     }
 

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -240,7 +240,10 @@ export class KoaDriver extends BaseDriver implements Driver {
                 options.response.redirect(action.redirect);
             }
 
-            return options.next();
+            if (this.automaticFallthrough || action.fallthrough)
+                return options.next();
+            else
+                return;
 
         } else if (action.renderedTemplate) { // if template is set then render it // todo: not working in koa
             const renderOptions = result && result instanceof Object ? result : {};
@@ -249,7 +252,10 @@ export class KoaDriver extends BaseDriver implements Driver {
                 await ctx.render(action.renderedTemplate, renderOptions);
             });
 
-            return options.next();
+            if (this.automaticFallthrough || action.fallthrough)
+                return options.next();
+            else
+                return;
 
         } else if (result !== undefined || action.undefinedResultCode) { // send regular result
             if (result === null || (result === undefined && action.undefinedResultCode)) {
@@ -268,18 +274,27 @@ export class KoaDriver extends BaseDriver implements Driver {
                     options.response.status = action.undefinedResultCode;
                 }
 
-                return options.next();
+                if (this.automaticFallthrough || action.fallthrough)
+                    return options.next();
+                else
+                    return;
             } else {
                 if (result instanceof Object) {
                     options.response.body = result;
                 } else {
                     options.response.body = result;
                 }
-                return options.next();
+                if (this.automaticFallthrough || action.fallthrough)
+                    return options.next();
+                else
+                    return;
             }
 
         } else {
-            return options.next();
+            if(action.fallthrough)
+                return options.next();
+            else
+                return;
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export * from "./decorator/CookieParams";
 export * from "./decorator/Ctx";
 export * from "./decorator/CurrentUser";
 export * from "./decorator/Delete";
+export * from "./decorator/Fallthrough";
 export * from "./decorator/Get";
 export * from "./decorator/Head";
 export * from "./decorator/Header";
@@ -177,6 +178,12 @@ export function createExecutor(driver: Driver, options: RoutingControllersOption
         driver.isDefaultErrorHandlingEnabled = options.defaultErrorHandler;
     } else {
         driver.isDefaultErrorHandlingEnabled = true;
+    }
+
+    if (options.automaticFallthrough !== undefined) {
+        driver.automaticFallthrough = options.automaticFallthrough;
+    } else {
+        driver.automaticFallthrough = false;
     }
 
     if (options.classTransformer !== undefined) {

--- a/src/metadata/ActionMetadata.ts
+++ b/src/metadata/ActionMetadata.ts
@@ -109,6 +109,11 @@ export class ActionMetadata {
     successHttpCode: number;
 
     /**
+     * Specifies if this action should fall through to future handlers or middleware or not.
+     */
+    fallthrough: boolean;
+
+    /**
      * Specifies redirection url for this action.
      */
     redirect: string;
@@ -173,6 +178,7 @@ export class ActionMetadata {
         const redirectHandler = responseHandlers.find(handler => handler.type === "redirect");
         const renderedTemplateHandler = responseHandlers.find(handler => handler.type === "rendered-template");
         const authorizedHandler = responseHandlers.find(handler => handler.type === "authorized");
+        const fallthroughHandler = responseHandlers.find(handler => handler.type === "fallthrough");
         const bodyParam = this.params.find(param => param.type === "body");
 
         if (classTransformerResponseHandler)
@@ -187,6 +193,8 @@ export class ActionMetadata {
             this.redirect = redirectHandler.value;
         if (renderedTemplateHandler)
             this.renderedTemplate = renderedTemplateHandler.value;
+        if (fallthroughHandler)
+            this.fallthrough = true;
 
         this.bodyExtraOptions = bodyParam ? bodyParam.extraOptions : undefined;
         this.isBodyUsed = !!this.params.find(param => param.type === "body" || param.type === "body-param");

--- a/src/metadata/types/ResponseHandlerType.ts
+++ b/src/metadata/types/ResponseHandlerType.ts
@@ -11,4 +11,5 @@ export type ResponseHandlerType = "success-code"
     |"on-null"
     |"on-undefined"
     |"response-class-transform-options"
-    |"authorized";
+    |"authorized"
+    |"fallthrough";

--- a/test/functional/express-middlewares.spec.ts
+++ b/test/functional/express-middlewares.spec.ts
@@ -140,7 +140,7 @@ describe("express middlewares", () => {
     });
 
     let app: any;
-    before(done => app = createExpressServer().listen(3001, done));
+    before(done => app = createExpressServer({ automaticFallthrough: true }).listen(3001, done));
     after(done => app.close(done));
 
     it("should call a global middlewares", () => {

--- a/test/functional/fallthrough-decorator.spec.ts
+++ b/test/functional/fallthrough-decorator.spec.ts
@@ -1,0 +1,50 @@
+import "reflect-metadata";
+import {Controller} from "../../src/decorator/Controller";
+import {Fallthrough} from "../../src/decorator/Fallthrough";
+import {UseAfter} from "../../src/decorator/UseAfter";
+import {Get} from "../../src/decorator/Get";
+import {createExpressServer, createKoaServer, getMetadataArgsStorage} from "../../src/index";
+import {assertRequest} from "./test-utils";
+const chakram = require("chakram");
+const expect = chakram.expect;
+
+describe("fallthrough-decorator behavior", () => {
+    let useAfter: boolean;
+
+    beforeEach(() => {
+        useAfter = undefined;
+    });
+
+    before(() => {
+        // reset metadata args storage
+        getMetadataArgsStorage().reset();
+
+        @Controller()
+        class FallthroughController {
+            @Get("/books")
+            @Fallthrough()
+            @UseAfter(function(req: any, res: any, next: (err?: any) => any) {
+                useAfter = true;
+            })
+            getAll() {
+                return "<html><body>All books</body></html>";
+            }
+        }
+    });
+
+    let expressApp: any, koaApp: any;
+    before(done => expressApp = createExpressServer().listen(3001, done));
+    after(done => expressApp.close(done));
+    before(done => koaApp = createKoaServer().listen(3002, done));
+    after(done => koaApp.close(done));
+
+    describe("get should respond with proper status code, headers and body content, and should call after middleware", () => {
+        assertRequest([3001, 3002], "get", "books", response => {
+            expect(response).to.have.status(200);
+            expect(response).to.have.header("content-type", "text/html; charset=utf-8");
+            expect(response.body).to.be.equal("<html><body>All books</body></html>");
+            expect(useAfter).to.be.equal(true);
+        });
+    });
+
+});

--- a/test/functional/koa-middlewares.spec.ts
+++ b/test/functional/koa-middlewares.spec.ts
@@ -136,7 +136,7 @@ describe("koa middlewares", () => {
     });
 
     let app: any;
-    before(done => app = createKoaServer().listen(3001, done));
+    before(done => app = createKoaServer({ automaticFallthrough: true }).listen(3001, done));
     after(done => app.close(done));
 
     it("should call a global middlewares", () => {


### PR DESCRIPTION
Route fallthrough (route handlers calling `next()` without parameters) is now off by default, as it is not the implicit behavior in Express (I don't use Koa, but it appears to have similar paradigms to Express). If a route needs to fall through to other routes or "after" middleware, `@Fallthrough()` can be placed on the route handler. If the user wants all routes to fallthrough by default, the new `automaticFallthrough` global option can be enabled when initializing `routing-controllers`.