### PR TITLE
Use response.render instead of express.render to provide locals correctly

### DIFF
--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -263,7 +263,7 @@ export class ExpressDriver extends BaseDriver implements Driver {
         } else if (action.renderedTemplate) { // if template is set then render it
             const renderOptions = result && result instanceof Object ? result : {};
 
-            this.express.render(action.renderedTemplate, renderOptions, (err: any, html: string) => {
+            options.response.render(action.renderedTemplate, renderOptions, (err: any, html: string) => {
                 if (err && action.isJsonTyped) {
                     return options.next(err);
 


### PR DESCRIPTION
`res.render` automatically provides `res.locals` to the view engine, whereas `app.render` does not. Use `res.render` so that `res.locals` properties work correctly in `@Render` actions.