### PR TITLE
Fix 404 text content-type for JSON controllers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     "name": "Umed Khudoiberdiev",
     "email": "pleerock.me@gmail.com"
   },
+  "contributors": [
+    {
+      "name": "Michał Lytek",
+      "url": "https://github.com/19majkel94"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/pleerock/routing-controllers.git"

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -278,14 +278,6 @@ export class ExpressDriver extends BaseDriver implements Driver {
                 options.next();
             });
         } 
-        else if (result != null) { // send regular result
-            if (action.isJsonTyped) {
-                options.response.json(result);
-            } else {
-                options.response.send(result);
-            }
-            options.next();
-        }
         else if (result === undefined) { // throw NotFoundError on undefined response
             const notFoundError = new NotFoundError();
             if (action.undefinedResultCode) {
@@ -293,11 +285,19 @@ export class ExpressDriver extends BaseDriver implements Driver {
             }
             throw notFoundError;
         }
-        else { // send null response
+        else if (result === null) { // send null response
             if (action.isJsonTyped) {
                 options.response.json(null);
             } else {
                 options.response.send(null);
+            }
+            options.next();
+        }
+        else { // send regular result
+            if (action.isJsonTyped) {
+                options.response.json(result);
+            } else {
+                options.response.send(result);
             }
             options.next();
         }

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -223,18 +223,14 @@ export class ExpressDriver extends BaseDriver implements Driver {
     handleSuccess(result: any, action: ActionMetadata, options: Action): void {
 
         // check if we need to transform result and do it
-        if (this.useClassTransformer && result && result instanceof Object) {
+        if (result && result instanceof Object && this.useClassTransformer) {
             const options = action.responseClassTransformOptions || this.classToPlainTransformOptions;
             result = classToPlain(result, options);
         }
 
         // set http status code
-        if (result === undefined) {
-            if (action.undefinedResultCode) {
-                if (action.undefinedResultCode instanceof Function) {
-                    throw new (action.undefinedResultCode as any)(options);
-                }
-            }
+        if (result === undefined && action.undefinedResultCode && action.undefinedResultCode instanceof Function) {
+            throw new (action.undefinedResultCode as any)(options);
         } 
         else if (result === null) {
             if (action.nullResultCode) {
@@ -290,14 +286,14 @@ export class ExpressDriver extends BaseDriver implements Driver {
             }
             options.next();
         }
-        else if (result === undefined) {
+        else if (result === undefined) { // throw NotFoundError on undefined response
             const notFoundError = new NotFoundError();
             if (action.undefinedResultCode) {
                 notFoundError.httpCode = action.undefinedResultCode as number;
             }
             throw notFoundError;
         }
-        else { // send null/undefined response
+        else { // send null response
             if (action.isJsonTyped) {
                 options.response.json(null);
             } else {

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -247,15 +247,6 @@ export class KoaDriver extends BaseDriver implements Driver {
 
             return options.next();
         }
-        else if (result != null) { // send regular result
-            if (result instanceof Object) {
-                options.response.body = result;
-            } else {
-                options.response.body = result;
-            }
-
-            return options.next();
-        }
         else if (result === undefined) { // throw NotFoundError on undefined response
             const notFoundError = new NotFoundError();
             if (action.undefinedResultCode) {
@@ -263,19 +254,28 @@ export class KoaDriver extends BaseDriver implements Driver {
             }
             throw notFoundError;
         }
-        else { // send null response
+        else if (result === null) { // send null response
             if (action.isJsonTyped) {
                 options.response.body = null;
             } else {
                 options.response.body = null;
             }
-
+            
             // Setting `null` as a `response.body` means to koa that there is no content to return
             // so we must reset the status codes here.
             if (action.nullResultCode) {
                 options.response.status = action.nullResultCode;
             } else {
                 options.response.status = 204;
+            }
+            
+            return options.next();
+        }
+        else { // send regular result
+            if (result instanceof Object) {
+                options.response.body = result;
+            } else {
+                options.response.body = result;
             }
 
             return options.next();


### PR DESCRIPTION
Solving #231.

I decided to throw `NotFoundError` when `undefined` is returned from an action. This should let error handler decide about formatting the JSON response for JSON controllers and text/plain or html for text responses.

However I think we should place the info about the route where the undefined has been returned. @pleerock @NoNameProvided do you have any idea about what info and how formated the error message should be? 😕 