### PR TITLE
Controller constructer called twice

### DIFF
--- a/src/metadata/ActionMetadata.ts
+++ b/src/metadata/ActionMetadata.ts
@@ -257,7 +257,8 @@ export class ActionMetadata {
      * Action method is an action defined in a user controller.
      */
     callMethod(params: any[]) {
-        return this.controllerMetadata.instance[this.method].apply(this.controllerMetadata.instance, params);
+        const controllerInstance = this.controllerMetadata.instance;
+        return controllerInstance[this.method].apply(controllerInstance, params);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
- Updated the ActionMetadata `callMethod` method to use the ControllerMetadata `instance` getter once.
- Fixes https://github.com/pleerock/routing-controllers/issues/239