### PR TITLE
Fix/authorization

### DIFF
--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -291,12 +291,10 @@ export class KoaDriver extends BaseDriver implements Driver {
     handleError(error: any, action: ActionMetadata | undefined, options: Action): any {
         if (this.isDefaultErrorHandlingEnabled) {
             const response: any = options.response;
-            console.log("ERROR: ", error);
 
             // set http status
             // note that we can't use error instanceof HttpError properly anymore because of new typescript emit process
             if (error.httpCode) {
-                console.log("setting status code: ", error.httpCode);
                 options.context.status = error.httpCode;
                 response.status = error.httpCode;
             } else {

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -103,7 +103,9 @@ export class KoaDriver extends BaseDriver implements Driver {
                 };
 
                 if (isPromiseLike(checkResult)) {
-                    return checkResult.then(result => handleError(result));
+                    return checkResult
+                        .then(result => handleError(result))
+                        .catch(error => this.handleError(error, actionMetadata, action));
                 } else {
                     handleError(checkResult);
                 }

--- a/test/functional/action-params.spec.ts
+++ b/test/functional/action-params.spec.ts
@@ -39,7 +39,7 @@ describe("action parameters", () => {
     let uploadedFilesFirstName: string;
     let uploadedFilesSecondName: string;
     let requestReq: any, requestRes: any;
-    
+
     beforeEach(() => {
         paramUserId = undefined;
         paramFirstId = undefined;
@@ -375,7 +375,6 @@ describe("action parameters", () => {
 
     describe("@Session(param) should allow to inject empty property", () => {
         assertRequest([3001, 3002], "get", "session-param-empty", response => {
-            console.log(response.body);
             expect(response).to.be.status(200);
             expect(response).to.have.header("content-type", "text/html; charset=utf-8");
             expect(response.body).to.be.equal("<html><body>true</body></html>");
@@ -829,7 +828,7 @@ describe("action parameters", () => {
         assertRequest([3001, 3002], "post", "photos-with-required", undefined, {}, response => {
             expect(response).to.be.status(400);
         });
-        
+
     });
 
 });

--- a/test/functional/express-error-handling.spec.ts
+++ b/test/functional/express-error-handling.spec.ts
@@ -18,7 +18,7 @@ describe("express error handling", () => {
         errorHandlerCalled = undefined;
         errorHandledSpecifically = undefined;
     });
-    
+
     before(() => {
 
         // reset metadata args storage
@@ -29,7 +29,7 @@ describe("express error handling", () => {
 
             error(error: any, request: any, response: any, next?: Function): any {
                 errorHandlerCalled = true;
-                console.log("ERROR HANDLED GLOBALLY: ", error);
+                // ERROR HANDLED GLOBALLY
                 next(error);
             }
 
@@ -39,7 +39,7 @@ describe("express error handling", () => {
 
             error(error: any, request: any, response: any, next?: Function): any {
                 errorHandledSpecifically = true;
-                console.log("ERROR HANDLED SPECIFICALLY: ", error);
+                // ERROR HANDLED SPECIFICALLY
                 next(error);
             }
 
@@ -48,9 +48,9 @@ describe("express error handling", () => {
         class SoftErrorHandler implements ExpressErrorMiddlewareInterface {
 
             error(error: any, request: any, response: any, next?: Function): any {
-                console.log("ERROR WAS IGNORED: ", error);
-                next();
-            }
+                                                                                   // ERROR WAS IGNORED
+                                                                                   next();
+                                                                                 }
 
         }
 
@@ -96,7 +96,7 @@ describe("express error handling", () => {
             photos() {
                 return "1234";
             }
-            
+
         }
     });
 

--- a/test/functional/express-error-handling.spec.ts
+++ b/test/functional/express-error-handling.spec.ts
@@ -48,9 +48,9 @@ describe("express error handling", () => {
         class SoftErrorHandler implements ExpressErrorMiddlewareInterface {
 
             error(error: any, request: any, response: any, next?: Function): any {
-                                                                                   // ERROR WAS IGNORED
-                                                                                   next();
-                                                                                 }
+                // ERROR WAS IGNORED
+                next();
+            }
 
         }
 

--- a/test/functional/express-global-before-error-handling.spec.ts
+++ b/test/functional/express-global-before-error-handling.spec.ts
@@ -31,7 +31,6 @@ describe("custom express global before middleware error handling", () => {
         @Middleware({ type: "before" })
         class GlobalBeforeMiddleware implements ExpressMiddlewareInterface {
             use(request: any, response: any, next?: Function): any {
-              console.log("GLOBAL BEFORE MIDDLEWARE CALLED");
               throw new CustomError();
             }
         }

--- a/test/functional/redirect-decorator.spec.ts
+++ b/test/functional/redirect-decorator.spec.ts
@@ -34,20 +34,17 @@ describe("dynamic redirect", function () {
             @Get("/template")
             @Redirect("/users/:owner")
             template() {
-                // console.log("/template");
                 return {owner: "pleerock", repo: "routing-controllers"};
             }
 
             @Get("/original")
             @Redirect("/users/pleerock")
             original() {
-                // console.log("/original");
             }
 
             @Get("/override")
             @Redirect("https://api.github.com")
             override() {
-                // console.log("/override");
                 return "/users/pleerock";
             }
 


### PR DESCRIPTION
Add the ability to throw custom errors in the authorization checker for Koa. 

This is the follow up of #233 to bring parity between the two driver.

It also 

 - adds test to prevent regression of this feature
 - remove forgotten console.logs from the tests

 