### PR TITLE
fix(Drivers): check auhorization before accepting files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,58 +1,61 @@
 # Changelog and release notes
 
-**0.7.2**
-- FIXED: Using `@Authorization` decorator with Koa caused 404 responses (ref #240)
+### 0.7.2
 
-**0.7.1**
+- FIXED: Using `@Authorization` decorator with Koa caused 404 responses (ref [#240](https://github.com/pleerock/routing-controllers/pull/240))
+- FIXED: Allow throwing custom errors in `authorizationChecker` (ref [#233](https://github.com/pleerock/routing-controllers/pull/233), ref [#247](https://github.com/pleerock/routing-controllers/pull/247))
+- FIXED: check auth permissions before accepting files for upload (ref [#251](https://github.com/pleerock/routing-controllers/pull/240))
 
-**0.7.0** *[BREAKING CHANGES]*
+### 0.7.1
 
-* some routing-controllers options has been changed and renamed
-* returned validation error value signature has changed
-* controllers and middlewares now can be specified in routing-controllers options
-* `MiddlewareInterface` was removed and instead `ExpressMiddlewareInterface` or `KoaMiddlewareInterface` should be used
-* `ExpressErrorMiddlewareInterface` was renamed into `ErrorMiddlewareInterface`
-* per-controller and per-action middlewares used in `@UseBefore` and `@UseAfter` now should not be marked with `@Middleware` decorator
-* `@MiddlewareGlobalBefore()` and `@MiddlewareGlobalAfter()` were removed and instead new signatures should be used: `@Middleware({ type: "before" })`
+### 0.7.0 [BREAKING CHANGES]
+
+- some routing-controllers options has been changed and renamed
+- returned validation error value signature has changed
+- controllers and middlewares now can be specified in routing-controllers options
+- `MiddlewareInterface` was removed and instead `ExpressMiddlewareInterface` or `KoaMiddlewareInterface` should be used
+- `ExpressErrorMiddlewareInterface` was renamed into `ErrorMiddlewareInterface`
+- per-controller and per-action middlewares used in `@UseBefore` and `@UseAfter` now should not be marked with `@Middleware` decorator
+- `@MiddlewareGlobalBefore()` and `@MiddlewareGlobalAfter()` were removed and instead new signatures should be used: `@Middleware({ type: "before" })`
 and `@Middleware({ type: "after" })`
-* named some decorator parameter names
-* added few new decorators to get all parameters like `@QueryParams`, `@Params`, `@HeaderParams` etc.
-* added `@Authorized` and `@CurrentUser` decorators
-* added new `@Ctx` decorator to use context with koa
-* `@NullResultCode` has been renamed to `@OnNull`, now supports error classes
-* `@UndefinedResultCode` has been renamed to `@OnUndefined`, now supports error classes
-* `@EmptyResultCode` has been removed. Use `@OnUndefined` decorator instead and return concrete types in your controllers.
-* added ability to create custom decorators
-* enabled validation by default
-* multiple bug fixes
-* codebase refactoring
-* removed `JsonResponse` and `TextResponse` decorators
+- named some decorator parameter names
+- added few new decorators to get all parameters like `@QueryParams`, `@Params`, `@HeaderParams` etc.
+- added `@Authorized` and `@CurrentUser` decorators
+- added new `@Ctx` decorator to use context with koa
+- `@NullResultCode` has been renamed to `@OnNull`, now supports error classes
+- `@UndefinedResultCode` has been renamed to `@OnUndefined`, now supports error classes
+- `@EmptyResultCode` has been removed. Use `@OnUndefined` decorator instead and return concrete types in your controllers.
+- added ability to create custom decorators
+- enabled validation by default
+- multiple bug fixes
+- codebase refactoring
+- removed `JsonResponse` and `TextResponse` decorators
 
-**0.6.10**
+### 0.6.10
 
 * added integration with `class-transform-validator` for deserialization and auto validation request parameters
 
-**0.6.2**
+### 0.6.2
 
 * made interceptors to support promises
 
-**0.6.1**
+### 0.6.1
 
-* added interceptors support
+- added interceptors support
 
-**0.6.0** *[BREAKING CHANGES]*
+### 0.6.0 [BREAKING CHANGES]
 
-* middleware and error handlers support
-* everything packed into "routing-controllers" main export
-* removed parseJson from @Body decorator
-* removed ActionOptions
-* removed responseType from action options and added @JsonResponse and @TextResponse decorators
-* added few more new decorators
-* fixed multiple issues with param decorators
-* fixed multiple bugs
-* refactored core
+- middleware and error handlers support
+- everything packed into "routing-controllers" main export
+- removed parseJson from @Body decorator
+- removed ActionOptions
+- removed responseType from action options and added @JsonResponse and @TextResponse decorators
+- added few more new decorators
+- fixed multiple issues with param decorators
+- fixed multiple bugs
+- refactored core
 
-**0.5.0**
+### 0.5.0
 
-* renamed package from `controllers.ts` to `routing-controllers`
-* added integration with `constructor-utils` for serialization and deserialization
+- renamed package from `controllers.ts` to `routing-controllers`
+- added integration with `constructor-utils` for serialization and deserialization

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -87,6 +87,7 @@ export class ExpressDriver extends BaseDriver implements Driver {
 
         // middlewares required for this action
         const defaultMiddlewares: any[] = [];
+
         if (actionMetadata.isBodyUsed) {
             if (actionMetadata.isJsonTyped) {
                 defaultMiddlewares.push(this.loadBodyParser().json(actionMetadata.bodyExtraOptions));
@@ -94,26 +95,13 @@ export class ExpressDriver extends BaseDriver implements Driver {
                 defaultMiddlewares.push(this.loadBodyParser().text(actionMetadata.bodyExtraOptions));
             }
         }
-        if (actionMetadata.isFileUsed || actionMetadata.isFilesUsed) {
-            const multer = this.loadMulter();
-            actionMetadata.params
-                .filter(param => param.type === "file")
-                .forEach(param => {
-                    defaultMiddlewares.push(multer(param.extraOptions).single(param.name));
-                });
-            actionMetadata.params
-                .filter(param => param.type === "files")
-                .forEach(param => {
-                    defaultMiddlewares.push(multer(param.extraOptions).array(param.name));
-                });
-        }
 
         if (actionMetadata.isAuthorizedUsed) {
             defaultMiddlewares.push((request: any, response: any, next: Function) => {
                 if (!this.authorizationChecker)
                     throw new AuthorizationCheckerNotDefinedError();
 
-                const action: Action = {request, response, next};
+                const action: Action = { request, response, next };
                 const checkResult = this.authorizationChecker(action, actionMetadata.authorizedRoles);
 
                 const handleError = (result: any) => {
@@ -133,6 +121,20 @@ export class ExpressDriver extends BaseDriver implements Driver {
                     handleError(checkResult);
                 }
             });
+        }
+
+        if (actionMetadata.isFileUsed || actionMetadata.isFilesUsed) {
+            const multer = this.loadMulter();
+            actionMetadata.params
+                .filter(param => param.type === "file")
+                .forEach(param => {
+                    defaultMiddlewares.push(multer(param.extraOptions).single(param.name));
+                });
+            actionMetadata.params
+                .filter(param => param.type === "files")
+                .forEach(param => {
+                    defaultMiddlewares.push(multer(param.extraOptions).array(param.name));
+                });
         }
 
         // user used middlewares

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -69,26 +69,13 @@ export class KoaDriver extends BaseDriver implements Driver {
 
         // middlewares required for this action
         const defaultMiddlewares: any[] = [];
-        if (actionMetadata.isFileUsed || actionMetadata.isFilesUsed) {
-            const multer = this.loadMulter();
-            actionMetadata.params
-                .filter(param => param.type === "file")
-                .forEach(param => {
-                    defaultMiddlewares.push(multer(param.extraOptions).single(param.name));
-                });
-            actionMetadata.params
-                .filter(param => param.type === "files")
-                .forEach(param => {
-                    defaultMiddlewares.push(multer(param.extraOptions).array(param.name));
-                });
-        }
 
         if (actionMetadata.isAuthorizedUsed) {
             defaultMiddlewares.push((context: any, next: Function) => {
                 if (!this.authorizationChecker)
                     throw new AuthorizationCheckerNotDefinedError();
 
-                const action: Action = {request: context.request, response: context.response, context, next};
+                const action: Action = { request: context.request, response: context.response, context, next };
                 const checkResult = actionMetadata.authorizedRoles instanceof Function ?
                     getFromContainer<RoleChecker>(actionMetadata.authorizedRoles).check(action) :
                     this.authorizationChecker(action, actionMetadata.authorizedRoles);
@@ -108,6 +95,20 @@ export class KoaDriver extends BaseDriver implements Driver {
                     handleError(checkResult);
                 }
             });
+        }
+
+        if (actionMetadata.isFileUsed || actionMetadata.isFilesUsed) {
+            const multer = this.loadMulter();
+            actionMetadata.params
+                .filter(param => param.type === "file")
+                .forEach(param => {
+                    defaultMiddlewares.push(multer(param.extraOptions).single(param.name));
+                });
+            actionMetadata.params
+                .filter(param => param.type === "files")
+                .forEach(param => {
+                    defaultMiddlewares.push(multer(param.extraOptions).array(param.name));
+                });
         }
 
         // user used middlewares


### PR DESCRIPTION
This PR fixes #250.  

Until now files where accepted before checking the authorization rights. Now both the Koa driver and Express driver correctly check the authorization first.

closes #250