### PR TITLE
Fixed express-session deprecation

### DIFF
--- a/test/fakes/global-options/SessionMiddleware.ts
+++ b/test/fakes/global-options/SessionMiddleware.ts
@@ -18,6 +18,8 @@ export class SessionMiddleware implements ExpressMiddlewareInterface {
 
     private expSession = session({
         secret: "19majkel94_helps_pleerock",
+        resave: false,
+        saveUninitialized: true,
     });
 
     private koaSession: any;


### PR DESCRIPTION
This PR adds two additional settings to the express test session. Those settings were optional, but their default values are now deprecated.

Sources:
* https://github.com/expressjs/session#saveuninitialized
* https://github.com/expressjs/session#resave