### PR TITLE
Directly calling response

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ export class UserController {
 
 #### Using Request and Response objects
 
-You can use framework's request and response objects this way:
+You can use framework's request and response objects directly. If you want to handle the response by yourself,
+just make sure you return the response object itself from the action.
 
 ```typescript
 import {Controller, Req, Res, Get} from "routing-controllers";
@@ -256,7 +257,7 @@ export class UserController {
 
     @Get("/users")
     getAll(@Req() request: any, @Res() response: any) {
-        response.send("Hello response!");
+        return response.send("Hello response!");
     }
 
 }
@@ -274,7 +275,7 @@ export class UserController {
 
     @Get("/users")
     getAll(@Req() request: Request, @Res() response: Response) {
-        response.send("Hello response!");
+        return response.send("Hello response!");
     }
 
 }

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -105,7 +105,7 @@ export class ExpressDriver extends BaseDriver {
                 const action: Action = { request, response, next };
                 try {
                     const checkResult = this.authorizationChecker(action, actionMetadata.authorizedRoles);
-    
+
                     const handleError = (result: any) => {
                         if (!result) {
                             let error = actionMetadata.authorizedRoles.length === 0 ? new AuthorizationRequiredError(action) : new AccessDeniedError(action);
@@ -114,7 +114,7 @@ export class ExpressDriver extends BaseDriver {
                             next();
                         }
                     };
-    
+
                     if (isPromiseLike(checkResult)) {
                         checkResult
                             .then(result => handleError(result))
@@ -229,6 +229,12 @@ export class ExpressDriver extends BaseDriver {
      * Handles result of successfully executed controller action.
      */
     handleSuccess(result: any, action: ActionMetadata, options: Action): void {
+
+        // if the action returned the response object itself, short-circuits
+        if (result && result === options.response) {
+            options.next();
+            return;
+        }
 
         // transform result if needed
         result = this.transformResult(result, action, options);

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -215,8 +215,7 @@ export class KoaDriver extends BaseDriver {
 
         // if the action returned the context or the response object itself, short-circuits
         if (result && (result === options.response || result === options.context)) {
-            options.next();
-            return;
+            return options.next();
         }
 
         // transform result if needed

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -81,7 +81,7 @@ export class KoaDriver extends BaseDriver {
                     const checkResult = actionMetadata.authorizedRoles instanceof Function ?
                         getFromContainer<RoleChecker>(actionMetadata.authorizedRoles).check(action) :
                         this.authorizationChecker(action, actionMetadata.authorizedRoles);
-    
+
                     const handleError = (result: any) => {
                         if (!result) {
                             let error = actionMetadata.authorizedRoles.length === 0 ? new AuthorizationRequiredError(action) : new AccessDeniedError(action);
@@ -90,7 +90,7 @@ export class KoaDriver extends BaseDriver {
                             return next();
                         }
                     };
-    
+
                     if (isPromiseLike(checkResult)) {
                         return checkResult
                             .then(result => handleError(result))
@@ -213,6 +213,12 @@ export class KoaDriver extends BaseDriver {
      */
     handleSuccess(result: any, action: ActionMetadata, options: Action): void {
 
+        // if the action returned the context or the response object itself, short-circuits
+        if (result && (result === options.response || result === options.context)) {
+            options.next();
+            return;
+        }
+
         // transform result if needed
         result = this.transformResult(result, action, options);
 
@@ -227,7 +233,7 @@ export class KoaDriver extends BaseDriver {
         } else if (action.successHttpCode) {
             options.response.status = action.successHttpCode;
         }
-        
+
         if (action.redirect) { // if redirect is set then do it
             if (typeof result === "string") {
                 options.response.redirect(result);
@@ -238,7 +244,7 @@ export class KoaDriver extends BaseDriver {
             }
         } else if (action.renderedTemplate) { // if template is set then render it // TODO: not working in koa
             const renderOptions = result && result instanceof Object ? result : {};
-            
+
             this.koa.use(async function (ctx: any, next: any) {
                 await ctx.render(action.renderedTemplate, renderOptions);
             });
@@ -275,7 +281,7 @@ export class KoaDriver extends BaseDriver {
                 options.response.body = result;
             }
         }
-        
+
         // apply http headers
         Object.keys(action.headers).forEach(name => {
             options.response.set(name, action.headers[name]);

--- a/test/functional/action-params.spec.ts
+++ b/test/functional/action-params.spec.ts
@@ -89,22 +89,24 @@ describe("action parameters", () => {
                 return "<html><body>hello</body></html>";
             }
 
-            @Get("/users/direct")
-            getUsersDirectExpress(@Res() response: any): any {
+            @Get("/users-direct")
+            getUsersDirect(@Res() response: any): any {
                 if (typeof response.send === "function")
-                    response.status(201).contentType("custom/x-sample").send("hi, I was written directly to the response");
+                    return response.status(201).contentType("custom/x-sample").send("hi, I was written directly to the response");
                 else {
                     response.status = 201;
-                    response.type = "custom/x-sample";
+                    response.type = "custom/x-sample; charset=utf-8";
                     response.body = "hi, I was written directly to the response";
+                    return response;
                 }
             }
 
-            @Get("/users/direct/ctx")
+            @Get("/users-direct/ctx")
             getUsersDirectKoa(@Ctx() ctx: any): any {
                 ctx.response.status = 201;
-                ctx.response.type = "custom/x-sample";
+                ctx.response.type = "custom/x-sample; charset=utf-8";
                 ctx.response.body = "hi, I was written directly to the response using Koa Ctx";
+                return ctx;
             }
 
             @Get("/users/:userId")
@@ -366,7 +368,7 @@ describe("action parameters", () => {
     });
 
     describe("writing directly to the response using @Res should work", () => {
-        assertRequest([3001, 3002], "get", "users/direct", response => {
+        assertRequest([3001, 3002], "get", "users-direct", response => {
             expect(response).to.be.status(201);
             expect(response.body).to.be.equal("hi, I was written directly to the response");
             expect(response).to.have.header("content-type", "custom/x-sample; charset=utf-8");
@@ -374,7 +376,7 @@ describe("action parameters", () => {
     });
 
     describe("writing directly to the response using @Ctx should work", () => {
-        assertRequest([3002], "get", "users/direct/ctx", response => {
+        assertRequest([3002], "get", "users-direct/ctx", response => {
             expect(response).to.be.status(201);
             expect(response.body).to.be.equal("hi, I was written directly to the response using Koa Ctx");
             expect(response).to.have.header("content-type", "custom/x-sample; charset=utf-8");

--- a/test/functional/action-params.spec.ts
+++ b/test/functional/action-params.spec.ts
@@ -6,6 +6,7 @@ import {assertRequest} from "./test-utils";
 import {User} from "../fakes/global-options/User";
 import {Controller} from "../../src/decorator/Controller";
 import {Get} from "../../src/decorator/Get";
+import {Ctx} from "../../src/decorator/Ctx";
 import {Req} from "../../src/decorator/Req";
 import {Res} from "../../src/decorator/Res";
 import {Param} from "../../src/decorator/Param";
@@ -86,6 +87,24 @@ describe("action parameters", () => {
                 requestReq = request;
                 requestRes = response;
                 return "<html><body>hello</body></html>";
+            }
+
+            @Get("/users/direct")
+            getUsersDirectExpress(@Res() response: any): any {
+                if (typeof response.send === "function")
+                    response.status(201).contentType("custom/x-sample").send("hi, I was written directly to the response");
+                else {
+                    response.status = 201;
+                    response.type = "custom/x-sample";
+                    response.body = "hi, I was written directly to the response";
+                }
+            }
+
+            @Get("/users/direct/ctx")
+            getUsersDirectKoa(@Ctx() ctx: any): any {
+                ctx.response.status = 201;
+                ctx.response.type = "custom/x-sample";
+                ctx.response.body = "hi, I was written directly to the response using Koa Ctx";
             }
 
             @Get("/users/:userId")
@@ -343,6 +362,22 @@ describe("action parameters", () => {
             expect(requestRes).to.be.instanceOf(Object); // apply better check here
             expect(response).to.be.status(200);
             expect(response).to.have.header("content-type", "text/html; charset=utf-8");
+        });
+    });
+
+    describe("writing directly to the response using @Res should work", () => {
+        assertRequest([3001, 3002], "get", "users/direct", response => {
+            expect(response).to.be.status(201);
+            expect(response.body).to.be.equal("hi, I was written directly to the response");
+            expect(response).to.have.header("content-type", "custom/x-sample; charset=utf-8");
+        });
+    });
+
+    describe("writing directly to the response using @Ctx should work", () => {
+        assertRequest([3002], "get", "users/direct/ctx", response => {
+            expect(response).to.be.status(201);
+            expect(response.body).to.be.equal("hi, I was written directly to the response using Koa Ctx");
+            expect(response).to.have.header("content-type", "custom/x-sample; charset=utf-8");
         });
     });
 


### PR DESCRIPTION
I've added some tests for the documented way to write to the response directly, as in: https://github.com/pleerock/routing-controllers#using-request-and-response-objects. It looks like #241 broke this usage pattern.