### PR TITLE
chore: set NODE_ENV to test when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "chai-as-promised": "^6.0.0",
     "chakram": "^1.4.0",
     "cors": "^2.8.3",
+    "cross-env": "5.0.5",
     "del": "^2.2.1",
     "express": "^4.15.2",
     "express-session": "^1.15.2",
@@ -89,7 +90,7 @@
     "typescript": "^2.2.2"
   },
   "scripts": {
-    "test": "gulp tests"
+    "test": "cross-env NODE_ENV=test gulp tests"
   },
   "typings": "index.d.ts"
 }


### PR DESCRIPTION
This PR set `NODE_ENV` to `test`. What will prevent Express default error handler to print error messages to the console.

Works on Windows, MacOs, Linux.
