### PR TITLE
ErrorHandler: invoke class specific toJSON transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,30 @@ There are set of prepared errors you can use:
 * NotFoundError
 * UnauthorizedError
 
-You can also create and use your own errors by extending `HttpError` class.
+
+You can also create and use your own errors by extending `HttpError` class.  
+To define the data returned to the client, you could define a toJSON method in your error.
+
+```typescript
+class DbError extends HttpError {
+    public operationName: string;
+    public args: any[];
+
+    constructor(operationName: string, args: any[] = []) {
+        super(500);
+        Object.setPrototypeOf(this, DbError.prototype);
+        this.operationName = operationName;
+        this.args = args; // can be used for internal logging
+    }
+
+    toJSON() {
+        return {
+            status: this.httpCode,
+            failedOperation: this.operationName
+        }
+    }
+}
+``` 
 
 #### Enable CORS
 

--- a/src/driver/BaseDriver.ts
+++ b/src/driver/BaseDriver.ts
@@ -150,6 +150,9 @@ export abstract class BaseDriver {
         if (!this.isDefaultErrorHandlingEnabled)
             return error;
 
+        if (typeof error.toJSON === "function")
+            return error.toJSON();
+        
         let processedError: any = {};
         if (error instanceof Error) {
             const name = error.name && error.name !== "Error" ? error.name : error.constructor.name;


### PR DESCRIPTION
Hi,
it would be great to have the ability to define a custom toJSON transformation of Errors before they are sent to the client.

UseCase:
We want to censor our custom Errors (extending HttpError) before they are leaving the server.
Therefore we thought to simply implement a toJSON method, like you can override the toString.
```ts
export class CustomError extends HttpError {
    public publicData: string;
    public secretData: string;

    constructor( httpCode: number, publicData: string, publicData: string ) {
        super( httpCode );
        Object.setPrototypeOf(this, CustomError.prototype);
        this.publicData = publicData;
        this.secretData = secretData;
    }

    toJSON () {
        return {
            httpCode: this.httpCode,
            publicData: this.publicData
        };
    }
}
```
Best Regards