### PR TITLE
chore: support only LTS and stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: node_js
 node_js:
   - stable
+  - 8
   - 6
-  - 5
-  - 4
-  #- 0.12
-  #- 0.11
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
There is 2 kind of users: 
  - ones trying out routing-controllers
  - and production users 

Production users (hopefully) uses LTS version of NodeJS and other users who experience with the project can be asked to update to the latest stable or LTS release. So supporting non LTS releases is just extra effort we should avoid. 

If I could not convince you, here is also an [article](https://medium.com/@mikeal/stop-supporting-old-releases-70cfa0e04b0c) about this from Mikeal.