### PR TITLE
fix: create controllers in specified order

### DIFF
--- a/src/metadata-builder/MetadataArgsStorage.ts
+++ b/src/metadata-builder/MetadataArgsStorage.ts
@@ -79,9 +79,11 @@ export class MetadataArgsStorage {
    * Filters registered controllers by a given classes.
    */
   filterControllerMetadatasForClasses(classes: Function[]): ControllerMetadataArgs[] {
-    return this.controllers.filter(ctrl => {
-      return classes.filter(cls => ctrl.target === cls).length > 0;
-    });
+    return classes.reduce<ControllerMetadataArgs[]>((ctrls, cls) => {
+      const ctrl = this.controllers.find(ctrl => ctrl.target === cls);
+      if (ctrl) ctrls.push(ctrl);
+      return ctrls;
+    }, []);
   }
 
   /**

--- a/test/functional/controller-order.spec.ts
+++ b/test/functional/controller-order.spec.ts
@@ -1,0 +1,63 @@
+import { Server as HttpServer } from 'http';
+import HttpStatusCodes from 'http-status-codes';
+import { Controller } from '../../src/decorator/Controller';
+import { Get } from '../../src/decorator/Get';
+import { createExpressServer, getMetadataArgsStorage } from '../../src/index';
+import { axios } from '../utilities/axios';
+import DoneCallback = jest.DoneCallback;
+
+describe(``, () => {
+  let expressServer: HttpServer;
+
+  describe('loaded direct from array', () => {
+    let controllerOrder: number[];
+
+    beforeEach(() => {
+      controllerOrder = [];
+    });
+
+    beforeAll((done: DoneCallback) => {
+      getMetadataArgsStorage().reset();
+
+      @Controller()
+      class ThirdController {
+        @Get('/*')
+        getAll() {
+          controllerOrder.push(3);
+          return 'OK';
+        }
+      }
+
+      @Controller()
+      class SecondController {
+        @Get('/second/*')
+        getAll() {
+          controllerOrder.push(2);
+          return 'OK';
+        }
+      }
+
+      @Controller()
+      class FirstController {
+        @Get('/second/first/*')
+        getAll() {
+          controllerOrder.push(1);
+          return 'OK';
+        }
+      }
+
+      expressServer = createExpressServer({
+        controllers: [FirstController, SecondController, ThirdController],
+      }).listen(3001, done);
+    });
+
+    afterAll((done: DoneCallback) => expressServer.close(done));
+
+    it('should call controllers in order defined by items order', async () => {
+      await axios.get('/second/first/any');
+      await axios.get('/second/any');
+      await axios.get('/any');
+      expect(controllerOrder).toEqual([1, 2, 3]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Controllers are created in the order they are passed into the router controller options, not in the order they are registered with metadata

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
Fixes typestack/routing-controllers#774
