### PR TITLE
fix: check if headersSent

### DIFF
--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -252,7 +252,7 @@ export class ExpressDriver extends BaseDriver {
    * Handles result of successfully executed controller action.
    */
   handleSuccess(result: any, action: ActionMetadata, options: Action): void {
-    if (action.response && action.response.headersSent) {
+    if (options && options.response && options.response.headersSent) {
       console.warn('Response headers were already sent, default handleSuccess will not be executed.');
       options.next();
       return;
@@ -359,7 +359,7 @@ export class ExpressDriver extends BaseDriver {
    * Handles result of failed executed controller action.
    */
   handleError(error: any, action: ActionMetadata | undefined, options: Action): any {
-    if (action.response && action.response.headersSent) {
+    if (options && options.response && options.response.headersSent) {
       console.warn('Response headers were already sent, default handleError will not be executed.');
       options.next(error);
       return;

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -253,7 +253,7 @@ export class ExpressDriver extends BaseDriver {
    */
   handleSuccess(result: any, action: ActionMetadata, options: Action): void {
     // if the action returned the response object itself, short-circuits
-    if (result && result === options.response) {
+    if (result && result === options.response || options.response.headersSent) {
       options.next();
       return;
     }
@@ -354,7 +354,7 @@ export class ExpressDriver extends BaseDriver {
    * Handles result of failed executed controller action.
    */
   handleError(error: any, action: ActionMetadata | undefined, options: Action): any {
-    if (this.isDefaultErrorHandlingEnabled) {
+    if (this.isDefaultErrorHandlingEnabled && !options.response.headersSent) {
       const response: any = options.response;
 
       // set http code

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -252,7 +252,7 @@ export class ExpressDriver extends BaseDriver {
    * Handles result of successfully executed controller action.
    */
   handleSuccess(result: any, action: ActionMetadata, options: Action): void {
-    if (action.response.headersSent) {
+    if (action.response && action.response.headersSent) {
       console.warn('Response headers were already sent, default handleSuccess will not be executed.');
       options.next();
       return;
@@ -359,7 +359,7 @@ export class ExpressDriver extends BaseDriver {
    * Handles result of failed executed controller action.
    */
   handleError(error: any, action: ActionMetadata | undefined, options: Action): any {
-    if (action.response.headersSent) {
+    if (action.response && action.response.headersSent) {
       console.warn('Response headers were already sent, default handleError will not be executed.');
       options.next(error);
       return;

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -252,8 +252,13 @@ export class ExpressDriver extends BaseDriver {
    * Handles result of successfully executed controller action.
    */
   handleSuccess(result: any, action: ActionMetadata, options: Action): void {
+    if (action.response.headersSent) {
+      console.warn('Response headers were already sent, default handleSuccess will not be executed.');
+      options.next();
+      return;
+    }
     // if the action returned the response object itself, short-circuits
-    if (result && result === options.response || options.response.headersSent) {
+    if (result && result === options.response) {
       options.next();
       return;
     }
@@ -354,7 +359,12 @@ export class ExpressDriver extends BaseDriver {
    * Handles result of failed executed controller action.
    */
   handleError(error: any, action: ActionMetadata | undefined, options: Action): any {
-    if (this.isDefaultErrorHandlingEnabled && !options.response.headersSent) {
+    if (action.response.headersSent) {
+      console.warn('Response headers were already sent, default handleError will not be executed.');
+      options.next(error);
+      return;
+    }
+    if (this.isDefaultErrorHandlingEnabled) {
       const response: any = options.response;
 
       // set http code


### PR DESCRIPTION
## Description

Check `response.headersSent` in both handleSuccess & handleError, prevents that response already sent and Express app crashed.
