### PR TITLE
Passing options with UseInterceptor

### DIFF
--- a/src/RoutingControllers.ts
+++ b/src/RoutingControllers.ts
@@ -172,6 +172,7 @@ export class RoutingControllers<T extends BaseDriver> {
    * Creates interceptors from the given "use interceptors".
    */
   protected prepareInterceptors(uses: InterceptorMetadata[]): Function[] {
+    uses.sort((interceptor1, interceptor2) => interceptor2.priority - interceptor1.priority);
     return uses.map(use => {
       if (use.interceptor.prototype && use.interceptor.prototype.intercept) {
         // if this is function instance of InterceptorInterface

--- a/src/decorator/UseInterceptor.ts
+++ b/src/decorator/UseInterceptor.ts
@@ -1,5 +1,16 @@
 import { getMetadataArgsStorage } from '../index';
 import { Action } from '../Action';
+import { UseInterceptorMetadataArgs } from '../metadata/args/UseInterceptorMetadataArgs';
+
+/**
+ * Specifies a given interceptor middleware or interceptor function, to which UseInterceptorMetadataArgs can be applied, to be used for controller or controller action. 
+ * Must be set to controller action or controller class.
+ */
+export function UseInterceptor(
+  optionsOrInterceptor: Partial<UseInterceptorMetadataArgs> | Function,
+  ...interceptors: Array<Function>
+): Function;
+
 
 /**
  * Specifies a given interceptor middleware or interceptor function to be used for controller or controller action.
@@ -8,22 +19,40 @@ import { Action } from '../Action';
 export function UseInterceptor(...interceptors: Array<Function>): Function;
 
 /**
+ * Specifies a given interceptor middleware or interceptor function, to which UseInterceptorMetadataArgs can be applied, to be used for controller or controller action. 
+ * Must be set to controller action or controller class.
+ */
+export function UseInterceptor(
+  optionsOrInterceptor: Partial<UseInterceptorMetadataArgs> | ((action: Action, result: any) => any),
+  ...interceptors: Array<(action: Action, result: any) => any>
+): Function;
+
+/**
  * Specifies a given interceptor middleware or interceptor function to be used for controller or controller action.
  * Must be set to controller action or controller class.
  */
 export function UseInterceptor(...interceptors: Array<(action: Action, result: any) => any>): Function;
 
 /**
- * Specifies a given interceptor middleware or interceptor function to be used for controller or controller action.
+ * Specifies a given interceptor middleware or interceptor function, to which UseInterceptorMetadataArgs can be applied, to be used for controller or controller action.
  * Must be set to controller action or controller class.
  */
-export function UseInterceptor(...interceptors: Array<Function | ((action: Action, result: any) => any)>): Function {
+export function UseInterceptor(
+  optionsOrInterceptor: Partial<UseInterceptorMetadataArgs> | Function | ((action: Action, result: any) => any),
+  ...interceptors: Array<Function | ((action: Action, result: any) => any)>
+): Function {
+  const optionsIsAnInterceptor = optionsOrInterceptor instanceof Function || Array.isArray(optionsOrInterceptor);
+  const options: Partial<UseInterceptorMetadataArgs> = optionsIsAnInterceptor
+    ? {}
+    : (optionsOrInterceptor as Partial<UseInterceptorMetadataArgs>);
   return function (objectOrFunction: Object | Function, methodName?: string) {
-    interceptors.forEach(interceptor => {
+    [...(optionsIsAnInterceptor ? [optionsOrInterceptor as Function] : []), ...interceptors].forEach(interceptor => {
       getMetadataArgsStorage().useInterceptors.push({
+        ...options,
         interceptor: interceptor,
         target: methodName ? objectOrFunction.constructor : (objectOrFunction as Function),
         method: methodName,
+        priority: options.priority ?? 0,
       });
     });
   };

--- a/src/decorator/UseInterceptor.ts
+++ b/src/decorator/UseInterceptor.ts
@@ -3,14 +3,13 @@ import { Action } from '../Action';
 import { UseInterceptorMetadataArgs } from '../metadata/args/UseInterceptorMetadataArgs';
 
 /**
- * Specifies a given interceptor middleware or interceptor function, to which UseInterceptorMetadataArgs can be applied, to be used for controller or controller action. 
+ * Specifies a given interceptor middleware or interceptor function, to which UseInterceptorMetadataArgs can be applied, to be used for controller or controller action.
  * Must be set to controller action or controller class.
  */
 export function UseInterceptor(
   optionsOrInterceptor: Partial<UseInterceptorMetadataArgs> | Function,
   ...interceptors: Array<Function>
 ): Function;
-
 
 /**
  * Specifies a given interceptor middleware or interceptor function to be used for controller or controller action.
@@ -19,7 +18,7 @@ export function UseInterceptor(
 export function UseInterceptor(...interceptors: Array<Function>): Function;
 
 /**
- * Specifies a given interceptor middleware or interceptor function, to which UseInterceptorMetadataArgs can be applied, to be used for controller or controller action. 
+ * Specifies a given interceptor middleware or interceptor function, to which UseInterceptorMetadataArgs can be applied, to be used for controller or controller action.
  * Must be set to controller action or controller class.
  */
 export function UseInterceptor(


### PR DESCRIPTION
## Description
When using routing controllers, I don't want to explicitly set an interceptor to each controller action even though I (might) want to specify the priority, in how they're applied to the controller action.

For example; I have a:
- Flush interceptor (for mikro-orm)
- An Interceptor that formats my controller action response (using class-validator and class-transformer)

When I now specify the flush interceptor on global or controller level, it only get's executed after my response has been formatted. I want the flush to happen before any controller action response formatting happens, without having to specify the flush interceptor, on every controller action, below the response formatting interceptor. 

This PR suggests a way to pass and specify options (in this case mostly for the priority prop) to the interceptors, and sorts them according to importance before being applied to each controller action.

This PR still requires tests and additional docs, but I want to get some opinions whether this is something that could be merged. 

Local development setup used: https://github.com/typestack/routing-controllers/issues/861
Project I tested this with (above setup required): https://github.com/driescroons/routing-controllers-interceptor-priority-testing

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [X] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [X] the pull request targets the *default* branch of the repository (`develop`)
- [X] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [X] I have run the project locally and verified that there are no errors

