### PR TITLE
Pass action (request and response) when resolving middleware from container

### DIFF
--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -416,12 +416,7 @@ export class ExpressDriver extends BaseDriver {
         // if this is function instance of ErrorMiddlewareInterface
         middlewareFunctions.push(function (error: any, request: any, response: any, next: (err: any) => any) {
           const instance = getFromContainer<ExpressErrorMiddlewareInterface>(use.middleware, { request, response });
-          return instance.error(
-            error,
-            request,
-            response,
-            next
-          );
+          return instance.error(error, request, response, next);
         });
       } else {
         middlewareFunctions.push(use.middleware);

--- a/src/driver/express/ExpressDriver.ts
+++ b/src/driver/express/ExpressDriver.ts
@@ -58,17 +58,19 @@ export class ExpressDriver extends BaseDriver {
     let middlewareWrapper;
 
     // if its an error handler then register it with proper signature in express
-    if ((middleware.instance as ExpressErrorMiddlewareInterface).error) {
+    if (middleware.target.prototype && middleware.target.prototype.error) {
       middlewareWrapper = (error: any, request: any, response: any, next: (err?: any) => any) => {
-        (middleware.instance as ExpressErrorMiddlewareInterface).error(error, request, response, next);
+        const instance = getFromContainer<ExpressErrorMiddlewareInterface>(middleware.target, { request, response });
+        instance.error(error, request, response, next);
       };
     }
 
     // if its a regular middleware then register it as express middleware
-    else if ((middleware.instance as ExpressMiddlewareInterface).use) {
+    else if (middleware.target.prototype && middleware.target.prototype.use) {
       middlewareWrapper = (request: any, response: any, next: (err: any) => any) => {
         try {
-          const useResult = (middleware.instance as ExpressMiddlewareInterface).use(request, response, next);
+          const instance = getFromContainer<ExpressMiddlewareInterface>(middleware.target, { request, response });
+          const useResult = instance.use(request, response, next);
           if (isPromiseLike(useResult)) {
             useResult.catch((error: any) => {
               this.handleError(error, undefined, { request, response, next });
@@ -84,7 +86,7 @@ export class ExpressDriver extends BaseDriver {
     if (middlewareWrapper) {
       // Name the function for better debugging
       Object.defineProperty(middlewareWrapper, 'name', {
-        value: middleware.instance.constructor.name,
+        value: middleware.target.name,
         writable: true,
       });
 
@@ -396,7 +398,8 @@ export class ExpressDriver extends BaseDriver {
         // if this is function instance of MiddlewareInterface
         middlewareFunctions.push((request: any, response: any, next: (err: any) => any) => {
           try {
-            const useResult = getFromContainer<ExpressMiddlewareInterface>(use.middleware).use(request, response, next);
+            const instance = getFromContainer<ExpressMiddlewareInterface>(use.middleware, { request, response });
+            const useResult = instance.use(request, response, next);
             if (isPromiseLike(useResult)) {
               useResult.catch((error: any) => {
                 this.handleError(error, undefined, { request, response, next });
@@ -412,7 +415,8 @@ export class ExpressDriver extends BaseDriver {
       } else if (use.middleware.prototype && use.middleware.prototype.error) {
         // if this is function instance of ErrorMiddlewareInterface
         middlewareFunctions.push(function (error: any, request: any, response: any, next: (err: any) => any) {
-          return getFromContainer<ExpressErrorMiddlewareInterface>(use.middleware).error(
+          const instance = getFromContainer<ExpressErrorMiddlewareInterface>(use.middleware, { request, response });
+          return instance.error(
             error,
             request,
             response,

--- a/src/driver/koa/KoaDriver.ts
+++ b/src/driver/koa/KoaDriver.ts
@@ -59,9 +59,9 @@ export class KoaDriver extends BaseDriver {
    * Registers middleware that run before controller actions.
    */
   registerMiddleware(middleware: MiddlewareMetadata): void {
-    if ((middleware.instance as KoaMiddlewareInterface).use) {
+    if (middleware.target.prototype && middleware.target.prototype.use) {
       this.koa.use(function (ctx: any, next: any) {
-        return (middleware.instance as KoaMiddlewareInterface).use(ctx, next);
+        return getFromContainer<KoaMiddlewareInterface>(middleware.target).use(ctx, next);
       });
     }
   }

--- a/src/metadata/MiddlewareMetadata.ts
+++ b/src/metadata/MiddlewareMetadata.ts
@@ -1,8 +1,4 @@
 import { MiddlewareMetadataArgs } from './args/MiddlewareMetadataArgs';
-import { ExpressMiddlewareInterface } from '../driver/express/ExpressMiddlewareInterface';
-import { ExpressErrorMiddlewareInterface } from '../driver/express/ExpressErrorMiddlewareInterface';
-import { getFromContainer } from '../container';
-import { KoaMiddlewareInterface } from '../driver/koa/KoaMiddlewareInterface';
 
 /**
  * Middleware metadata.
@@ -41,18 +37,5 @@ export class MiddlewareMetadata {
     this.target = args.target;
     this.priority = args.priority;
     this.type = args.type;
-  }
-
-  // -------------------------------------------------------------------------
-  // Accessors
-  // -------------------------------------------------------------------------
-
-  /**
-   * Gets middleware instance from the container.
-   */
-  get instance(): ExpressMiddlewareInterface | KoaMiddlewareInterface | ExpressErrorMiddlewareInterface {
-    return getFromContainer<ExpressMiddlewareInterface | KoaMiddlewareInterface | ExpressErrorMiddlewareInterface>(
-      this.target
-    );
   }
 }


### PR DESCRIPTION
## Description
With in mind that resolving instances is done via:
```
interface IocAdapter {
  get<T>(someClass: ClassConstructor<T>, action?: Action): T;
}
```
When resolving controllers and interceptors `action` parameter is passed, while for middlewares it is not. Perhaps it should be consistent.

My goal is to have a HTTP request scoped containers. Meaning, if I want to have an injectable class e.g. `RequestContext` which contains information about the request that other services can consume I must have only one instance per HTTP request for such class. I could achieve this by opening child container for each HTTP request and bind it as a constant. The problem is where to keep child container. My current thinking is it should be part of the `request`, like:
```
export class InversifyAdapter implements IocAdapter {
  constructor(private readonly container: Container) {}

  get<T>(someClass: ClassConstructor<T>, action?: Action): T {
    if (!action) {
      // global resolution
      return this.container.get<T>(someClass)
    }

    if (!action?.request?.iocContainer) {
      action.request.iocContainer = this.container.createChild()
      // ... bind stuff
    } 

    // request-scoped resolution
    return action.request.iocContainer.get<T>(someClass)
  }
}

```
Which works fine for e.g. controllers, but not for middlewares which have injected dependencies through a constructor. As a workaround I can in middleware `use` method resolve dependencies via `request.iocContainer`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors
