### PR TITLE
Updated Codecov action to v3

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -27,10 +27,14 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci --ignore-scripts
       - run: npm run test:ci
-      - run: npm install codecov -g
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
         if: ${{ matrix.node-version == 'current' }}
-      - run: codecov -f ./coverage/clover.xml -t ${{ secrets.CODECOV_TOKEN }} --commit=$GITHUB_SHA --branch=${GITHUB_REF##*/}
-        if: ${{ matrix.node-version == 'current' }}
+        with:
+          file: ./coverage/clover.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          commit: ${{ github.sha }}
+          branch: ${{ github.ref }}
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
I've noticed builds are failing on step of Codecov:
```
==> Uploading reports
(node:1805) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
/opt/hostedtoolcache/node/23.2.0/x64/lib/node_modules/codecov/lib/codecov.js:213
        var codecov_report_url = result.split('\n')[0]
                                        ^

TypeError: result.split is not a function
    at /opt/hostedtoolcache/node/23.2.0/x64/lib/node_modules/codecov/lib/codecov.js:213:41
    at /opt/hostedtoolcache/node/23.2.0/x64/lib/node_modules/codecov/node_modules/teeny-request/build/src/index.js:210:17
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

I've decided to upgrade it to the latest Codecov stable version (v3).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors
